### PR TITLE
Typed models, bot decomposition, and scoring fixes

### DIFF
--- a/src/balatro_bot/bot.py
+++ b/src/balatro_bot/bot.py
@@ -8,30 +8,17 @@ import random
 import re
 import string
 import time
-from collections import defaultdict
 from dataclasses import dataclass, field
 
 import httpx
 from balatrobot import APIError, BalatroClient
 
+from balatro_bot.bot_format import fmt_card, format_card_detail
 from balatro_bot.engine import RuleEngine
 
 log = logging.getLogger("balatro_bot")
 _stream_log = logging.getLogger("balatro_stream")
-
-# Card formatting constants (used throughout the game loop)
-SUIT_SYM = {"H": "\u2665", "D": "\u2666", "C": "\u2663", "S": "\u2660"}
-RANK_SYM = {
-    "2": "2", "3": "3", "4": "4", "5": "5", "6": "6",
-    "7": "7", "8": "8", "9": "9", "T": "10",
-    "J": "J", "Q": "Q", "K": "K", "A": "A",
-}
-
-
-def fmt_card(c: dict) -> str:
-    """Format a card dict as a compact label like '10♥' or 'A♠'."""
-    val = c.get("value", {})
-    return RANK_SYM.get(val.get("rank", ""), "?") + SUIT_SYM.get(val.get("suit", ""), "?")
+_scoring_log = logging.getLogger("balatro_scoring")
 
 
 @dataclass
@@ -152,329 +139,11 @@ def wait_for_server(client: BalatroClient, timeout: float = 30.0) -> None:
     raise TimeoutError(f"balatrobot API not reachable after {timeout}s")
 
 
-_scoring_log = logging.getLogger("balatro_scoring")
+# ---------------------------------------------------------------------------
+# Core loop helpers (state queries, victory detection)
+# ---------------------------------------------------------------------------
 
-def _log_played_hand(snapshot: dict | None, pre_chips: int, new_state: dict, fmt_card) -> None:
-    """Log a detailed scoring breakdown for a hand that was just played."""
-    if not snapshot or not _scoring_log.handlers:
-        return
-    try:
-        from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
-        from balatro_bot.domain.scoring.estimate import score_hand_detailed
-
-        played = snapshot["played"]
-        hand_name = snapshot["hand_name"]
-        if not hand_name:
-            hand_name = classify_hand(played)
-
-        joker_keys = {j.get("key") for j in snapshot["jokers"]}
-        has_splash = "j_splash" in joker_keys
-        four_fingers = "j_four_fingers" in joker_keys
-        smeared = "j_smeared" in joker_keys
-        shortcut = "j_shortcut" in joker_keys
-        scoring = played if has_splash else _scoring_cards_for(hand_name, played, four_fingers=four_fingers, smeared=smeared, shortcut=shortcut)
-
-        # Apply boss blind level adjustments for scoring estimate
-        # NOTE: The Flint halving is already applied in the snapshot (line ~675),
-        # so we must NOT halve again here — that caused double-halving.
-        hand_levels = snapshot["hand_levels"]
-        blind_name = snapshot.get("blind_name", "")
-        boss_disabled = snapshot.get("_boss_disabled", False)
-        if blind_name == "The Arm" and not boss_disabled:
-            from balatro_bot.domain.scoring.base import arm_reduce_hand_levels
-            hand_levels = arm_reduce_hand_levels(hand_levels)
-
-        # Boss blind hand-type restrictions — zero estimate when hand is invalid
-        blind_zeroed = False
-        if not boss_disabled:
-            if blind_name == "The Mouth":
-                current_played = False
-                other_played = False
-                for ht, data in hand_levels.items():
-                    if isinstance(data, dict) and data.get("played_this_round", 0) > 0:
-                        if ht == hand_name:
-                            current_played = True
-                        else:
-                            other_played = True
-                if other_played and not current_played:
-                    blind_zeroed = True
-            elif blind_name == "The Eye":
-                for ht, data in hand_levels.items():
-                    if ht == hand_name and isinstance(data, dict) and data.get("played_this_round", 0) > 0:
-                        blind_zeroed = True
-                        break
-            elif blind_name == "The Psychic" and len(played) < 5:
-                blind_zeroed = True
-
-        # The Ox locks most-played hand at blind start
-        _ox_mp = snapshot.get("_ox_most_played")
-
-        detail = score_hand_detailed(
-            hand_name, scoring,
-            hand_levels=hand_levels,
-            jokers=snapshot["jokers"],
-            played_cards=played,
-            held_cards=snapshot["held"],
-            money=snapshot["money"],
-            discards_left=snapshot["discards_left"],
-            hands_left=snapshot["hands_left"],
-            joker_limit=snapshot["joker_limit"],
-            ancient_suit=snapshot.get("ancient_suit"),
-            deck_count=snapshot.get("deck_count", 0),
-            deck_cards=snapshot.get("deck_cards"),
-            blind_name="" if boss_disabled else blind_name,
-            ox_most_played=_ox_mp,
-        )
-
-        if blind_zeroed:
-            detail["total"] = 0
-
-        post_chips = new_state.get("round", {}).get("chips", 0)
-        actual_chips = post_chips - pre_chips
-        actual_reliable = actual_chips > 0
-        cards_str = ", ".join(fmt_card(c) for c in played)
-
-        joker_parts = []
-        for entry in detail["joker_contributions"]:
-            label, dc, dm = entry[0], entry[1], entry[2]
-            xm = entry[3] if len(entry) > 3 else 1.0
-            parts = []
-            if dc:
-                parts.append(f"+{dc:.0f}c")
-            # Show xmult as multiplier if it's clearly multiplicative (ratio > 1.1 or < 0.9)
-            if xm > 1.01 or xm < 0.99:
-                parts.append(f"x{xm:.2f}")
-            elif dm:
-                parts.append(f"+{dm:.1f}m")
-            if parts:
-                joker_parts.append(f"{label}({', '.join(parts)})")
-        joker_str = ", ".join(joker_parts) if joker_parts else "none"
-
-        mismatch = ""
-        is_mismatch = actual_reliable and detail["total"] != actual_chips
-        # Probability-based effects make scoring non-deterministic — the bot
-        # uses expected values but the game rolls dice.  Tag these as noise.
-        if is_mismatch:
-            noise_sources = []
-            if "j_misprint" in joker_keys:
-                noise_sources.append("misprint")
-            if "j_bloodstone" in joker_keys:
-                noise_sources.append("bloodstone")
-            # Space Joker: 1/8 chance to upgrade hand level — unpredictable
-            if "j_space" in joker_keys:
-                noise_sources.append("space")
-            # Lucky cards: 1/5 chance for +20 mult per scored Lucky card
-            if any(
-                isinstance(c.get("modifier", {}), dict)
-                and c.get("modifier", {}).get("enhancement") == "LUCKY"
-                for c in scoring
-            ):
-                noise_sources.append("lucky")
-            # Hook's boss effect (discard 2 cards) fires BEFORE On Played
-            # jokers.  Modelled: Green Joker, Ramen, Yorick.
-            # Castle/Hit the Road gain from Hook's random discards — inherently
-            # noisy since we can't predict which cards Hook picks.
-            if blind_name == "The Hook":
-                hook_noisy = {"j_castle", "j_hit_the_road",
-                              "j_ride_the_bus",
-                              "j_runner", "j_square", "j_trousers", "j_wee",
-                              "j_lucky_cat", "j_obelisk"}
-                for jk in joker_keys & hook_noisy:
-                    noise_sources.append(f"hook+{jk.removeprefix('j_')}")
-                # Hook removes held cards before scoring — held-card effects
-                # (Steel, Baron, Smiley Face, Blackboard) see a reduced hand
-                # that the bot can't predict.
-                held = snapshot.get("held", [])
-                _hmod = lambda c: c.get("modifier", {}) if isinstance(c.get("modifier", {}), dict) else {}
-                if any(_hmod(c).get("enhancement") == "STEEL" for c in held):
-                    noise_sources.append("hook+steel")
-                if "j_baron" in joker_keys and any(c.get("value", {}).get("rank") == "K" for c in held):
-                    noise_sources.append("hook+baron")
-                if "j_smiley" in joker_keys:
-                    noise_sources.append("hook+smiley")
-                if "j_blackboard" in joker_keys:
-                    noise_sources.append("hook+blackboard")
-            if noise_sources:
-                diff = actual_chips - detail["total"]
-                mismatch = f" MISMATCH_NOISE(diff={diff:+d}, {'+'.join(noise_sources)})"
-                is_mismatch = False
-        if is_mismatch:
-            diff = actual_chips - detail["total"]
-            if abs(diff) <= 1:
-                mismatch = f" MISMATCH_NOISE(diff={diff:+d}, rounding)"
-                is_mismatch = False
-            else:
-                mismatch = f" MISMATCH(diff={diff:+d})"
-        if not mismatch and not actual_reliable:
-            mismatch = " (actual unreliable)"
-
-        scoring_str = ", ".join(fmt_card(c) for c in scoring)
-
-        def _mod(c: dict) -> dict:
-            m = c.get("modifier", {})
-            return m if isinstance(m, dict) else {}
-
-        enhs_str = ",".join(sorted(filter(None, {_mod(c).get("enhancement", "") for c in scoring})))
-        seals_str = ",".join(sorted(filter(None, {_mod(c).get("seal", "") for c in scoring})))
-        eds_str = ",".join(sorted(filter(None, {_mod(c).get("edition", "") for c in scoring})))
-
-        _scoring_log.info(
-            "%s [%s] scoring=[%s](%d) | base: %d/%d | pre-joker: %d/%.1f | jokers: [%s] | "
-            "final: %d/%.1f | enhs=[%s] seals=[%s] eds=[%s] | "
-            "blind=%s ante=%d hands_left=%d | est=%d actual=%d%s",
-            detail["hand_name"], cards_str, scoring_str, len(scoring),
-            detail["base_chips"], detail["base_mult"],
-            detail["pre_joker_chips"], detail["pre_joker_mult"],
-            joker_str,
-            detail["post_joker_chips"], detail["post_joker_mult"],
-            enhs_str, seals_str, eds_str,
-            snapshot.get("blind_name", ""), snapshot.get("ante", 0), snapshot.get("hands_left", 0),
-            detail["total"], actual_chips,
-            mismatch,
-        )
-
-        # On mismatch, dump per-card scoring breakdown and raw card data
-        if is_mismatch:
-            from balatro_bot.cards import card_chip_value, card_mult_value, card_xmult_value, _modifier
-            from balatro_bot.joker_effects import parse_effect_value, retrigger_count, ScoreContext
-
-            # Dump raw hand level data from API for this hand type
-            hand_level_data = snapshot["hand_levels"].get(hand_name, {})
-            _scoring_log.info("  hand_level[%s] = %s", hand_name, hand_level_data)
-
-            # Score context intermediate states
-            _scoring_log.info(
-                "  scoring_ctx: base=%d/%d pre_joker=%d/%.1f post_joker=%d/%.1f total=%d",
-                detail["base_chips"], detail["base_mult"],
-                detail["pre_joker_chips"], detail["pre_joker_mult"],
-                detail["post_joker_chips"], detail["post_joker_mult"],
-                detail["total"],
-            )
-
-            # Build minimal context for retrigger calculation
-            ctx_for_retrigger = ScoreContext(
-                chips=0, mult=0.0, hand_name=hand_name,
-                scoring_cards=scoring, played_cards=played,
-                held_cards=snapshot["held"], hand_levels=snapshot["hand_levels"],
-                jokers=snapshot["jokers"], money=0, discards_left=0, hands_left=1,
-                joker_limit=snapshot.get("joker_limit", 5),
-                pareidolia="j_pareidolia" in joker_keys,
-                smeared="j_smeared" in joker_keys,
-            )
-
-            for i, c in enumerate(scoring):
-                mod = _modifier(c)
-                rank = c.get("value", {}).get("rank", "?")
-                suit = c.get("value", {}).get("suit", "?")
-                enh = mod.get("enhancement", "")
-                edition = mod.get("edition", "")
-                seal = mod.get("seal", "")
-                debuff = c.get("state", {})
-                if isinstance(debuff, dict):
-                    debuff = debuff.get("debuff", False)
-                else:
-                    debuff = False
-                chips = card_chip_value(c)
-                mult = card_mult_value(c)
-                xmult = card_xmult_value(c)
-                perma = c.get("value", {}).get("perma_bonus", 0) or 0
-                triggers = retrigger_count(c, ctx_for_retrigger)
-                _scoring_log.info(
-                    "  card[%d] %s %s (SCORING) | chips=%d mult=%.1f xmult=%.2f triggers=%d | "
-                    "enh=%s ed=%s seal=%s debuff=%s perma=%d | raw_mod=%s",
-                    i, rank, suit,
-                    chips, mult, xmult, triggers,
-                    enh or "-", edition or "-", seal or "-", debuff, perma,
-                    mod,
-                )
-            # Dump all held cards (Baron checks Kings, Shoot the Moon checks Queens, etc.)
-            for i, c in enumerate(snapshot["held"]):
-                mod_h = _modifier(c)
-                rank_h = c.get("value", {}).get("rank", "?")
-                suit_h = c.get("value", {}).get("suit", "?")
-                enh_h = mod_h.get("enhancement", "")
-                _scoring_log.info("  held[%d] %s %s | enh=%s", i, rank_h, suit_h, enh_h or "-")
-            # Dump raw joker ability data + parsed values so we can compare
-            for i, j in enumerate(snapshot["jokers"]):
-                ability = j.get("value", {}).get("ability", {})
-                effect = j.get("value", {}).get("effect", "") or ""
-                if not isinstance(effect, str):
-                    effect = ""
-                parsed = parse_effect_value(effect)
-                rarity = j.get("value", {}).get("rarity", "?")
-                jmod = j.get("modifier", {})
-                if not isinstance(jmod, dict):
-                    jmod = {}
-                jed = jmod.get("edition", "")
-                jed_parts = []
-                if jed:
-                    jed_parts.append(jed)
-                    if jmod.get("edition_mult"):
-                        jed_parts.append(f"mult={jmod['edition_mult']}")
-                    if jmod.get("edition_chips"):
-                        jed_parts.append(f"chips={jmod['edition_chips']}")
-                    if jmod.get("edition_x_mult"):
-                        jed_parts.append(f"x_mult={jmod['edition_x_mult']}")
-                jed_str = " ".join(jed_parts) if jed_parts else "-"
-                _scoring_log.info(
-                    "  joker[%d] %s | rarity=%s ed=%s | ability=%s | parsed=%s | effect=%s",
-                    i, j.get("key", "?"), rarity, jed_str, ability, parsed,
-                    effect[:120] if effect else "-",
-                )
-    except Exception as e:
-        _scoring_log.warning("scoring log error: %s", e)
-
-
-def _format_deck_snapshot(deck_cards: list) -> str:
-    """Format a compact deck snapshot for logging at ante transitions."""
-    ENHANCEMENT_ABBR = {
-        "GLASS": "GL", "STEEL": "ST", "WILD": "WL",
-        "BONUS": "BN", "GOLD": "GD", "LUCKY": "LK", "MULT": "MU",
-    }
-    SEAL_ABBR = {
-        "Red Seal": "RS", "Gold Seal": "GS",
-        "Blue Seal": "BS", "Purple Seal": "PS",
-    }
-    SUIT_SYM = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"}
-    RANK_ORDER = ["A", "K", "Q", "J", "T", "9", "8", "7", "6", "5", "4", "3", "2"]
-
-    by_rank: dict[str, list] = defaultdict(list)
-    stone_count = 0
-
-    for card in deck_cards:
-        mod = card.get("modifier", {})
-        if not isinstance(mod, dict):
-            mod = {}
-        enh = mod.get("enhancement", "")
-        if enh == "STONE":
-            stone_count += 1
-            continue
-        rank = card.get("value", {}).get("rank")
-        suit = card.get("value", {}).get("suit")
-        if not rank or not suit:
-            continue
-        seal = mod.get("seal", "")
-        by_rank[rank].append((suit, enh, seal))
-
-    parts = []
-    for rank in RANK_ORDER:
-        if rank not in by_rank:
-            continue
-        inner = rank
-        for suit, enh, seal in sorted(by_rank[rank], key=lambda x: x[0]):
-            sym = SUIT_SYM.get(suit, suit)
-            suffix = ENHANCEMENT_ABBR.get(enh, "") + SEAL_ABBR.get(seal, "")
-            inner += sym + suffix
-        parts.append(f"[{inner}]")
-
-    if stone_count:
-        parts.append(f"[STN×{stone_count}]")
-
-    total = sum(len(v) for v in by_rank.values()) + stone_count
-    return f"({total}): " + " ".join(parts)
-
-
-def _find_current_blind(state: dict) -> tuple[str, int | str] | None:
+def find_current_blind(state: dict) -> tuple[str, int | str] | None:
     """Find the current/selected blind from game state. Returns (name, score) or None."""
     for b in state.get("blinds", {}).values():
         if isinstance(b, dict) and b.get("status") == "CURRENT":
@@ -490,6 +159,8 @@ def _check_victory(
     pre_play_chips: int = 0, expected_hand_score: int = 0,
 ) -> bool:
     """Detect ante 9+ victory. Returns True if newly detected."""
+    from balatro_bot.bot_logging import log_blind_result
+
     ante = state.get("ante_num", 0)
     if ante < 9 or gs.actually_won:
         return False
@@ -522,370 +193,15 @@ def _check_victory(
         )
         _stream_log.info("")
         _stream_log.info("*** VICTORY! ***")
-        _log_blind_result(gs, "WON")
+        log_blind_result(gs, "WON")
 
     gs.current_blind_name = None
     return True
 
 
-def _log_blind_result(gs: GameLoopState, result: str = "WON") -> None:
-    """Log round summary for the current blind, then clear current_blind_name."""
-    if not gs.current_blind_name:
-        return
-    target_str = (
-        f"{gs.current_blind_target:,}"
-        if isinstance(gs.current_blind_target, int)
-        else gs.current_blind_target
-    )
-    hands_used = gs.total_hands_played - gs.hands_at_blind_start
-    discards_used = gs.total_discards_used - gs.discards_at_blind_start
-    log.info(
-        "[ROUND] %s: scored %s / needed %s — %s | %d hands, %d discards",
-        gs.current_blind_name, f"{gs.max_chips_this_blind:,}",
-        target_str, result, hands_used, discards_used,
-    )
-    if result == "WON":
-        _stream_log.info(
-            "%s WON — %s / %s | %d hands, %d discards",
-            gs.current_blind_name, f"{gs.max_chips_this_blind:,}",
-            target_str, hands_used, discards_used,
-        )
-
-
-def _format_card_detail(method: str, params: dict | None, state: dict) -> str:
-    """Build card detail string for action logging."""
-    if method in ("play", "discard") and "cards" in (params or {}):
-        hand_cards = state.get("hand", {}).get("cards", [])
-        indices = params["cards"]
-        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
-        return f" [{', '.join(labels)}]"
-    if method == "use" and params and "cards" in params:
-        hand_cards = state.get("hand", {}).get("cards", [])
-        indices = params["cards"]
-        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
-        return f" targets:[{', '.join(labels)}]"
-    if method == "pack" and params and "targets" in params:
-        hand_cards = state.get("hand", {}).get("cards", [])
-        indices = params["targets"]
-        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
-        return f" targets:[{', '.join(labels)}]"
-    return ""
-
-
-def _log_action(
-    gs: GameLoopState, game_state: str, method: str, params: dict | None,
-    action: object, card_detail: str, state: dict,
-) -> None:
-    """Log action to both main and stream loggers."""
-    log.info(
-        "[#%d] %s -> %s(%s)%s | %s",
-        gs.actions_taken, game_state, method, params or "",
-        card_detail, getattr(action, "reason", ""),
-    )
-
-    reason = getattr(action, "reason", "")
-    if method == "play" and card_detail:
-        if reason.startswith("milk:"):
-            _stream_log.info("Milk: %s", reason[5:].strip())
-        else:
-            score_m = re.search(r"for (\d+)", reason)
-            hand_name_str = getattr(action, "hand_name", "") or "?"
-            score_str = f"{int(score_m.group(1)):,}" if score_m else "?"
-            chips_remaining = state.get("round", {}).get("chips", 0)
-            blind_need = gs.current_blind_target if isinstance(gs.current_blind_target, int) else 0
-            remaining = blind_need - chips_remaining if blind_need else 0
-            _stream_log.info(
-                "Play %s → %s / %s needed",
-                hand_name_str, score_str,
-                f"{remaining:,}" if remaining > 0 else "0",
-            )
-    elif method == "discard" and card_detail:
-        chase_m = re.search(r"chase (\w[\w ]*?) \((\d+)%", reason) if reason else None
-        if chase_m:
-            _stream_log.info(
-                "Discard — chasing %s (%s%%)",
-                chase_m.group(1), chase_m.group(2),
-            )
-        else:
-            _stream_log.info("Discard")
-    elif method == "buy":
-        _stream_log.info("Bought: %s", reason.split("(")[0].strip() if reason else "?")
-    elif method == "next_round":
-        _stream_log.info("")
-
-
-def _build_play_snapshot(state: dict, params: dict, action: object) -> dict:
-    """Build the pre-play snapshot dict for scoring diagnostics."""
-    hand_cards_snap = state.get("hand", {}).get("cards", [])
-    play_indices = set(params.get("cards", []))
-
-    # Detect The Flint and halve hand levels for accurate scoring
-    snap_hand_levels = state.get("hands", {})
-    if not state.get("_boss_disabled", False):
-        blind_info = _find_current_blind(state)
-        if blind_info and blind_info[0] == "The Flint":
-            from balatro_bot.domain.scoring.base import flint_halve_hand_levels
-            snap_hand_levels = flint_halve_hand_levels(snap_hand_levels)
-
-    blind_info = _find_current_blind(state)
-    snap_blind_name = blind_info[0] if blind_info else ""
-
-    return {
-        "played": [hand_cards_snap[i] for i in sorted(params.get("cards", [])) if i < len(hand_cards_snap)],
-        "held": [c for j, c in enumerate(hand_cards_snap) if j not in play_indices],
-        "jokers": state.get("jokers", {}).get("cards", []),
-        "hand_levels": snap_hand_levels,
-        "money": state.get("money", 0),
-        "discards_left": state.get("round", {}).get("discards_left", 0),
-        # Game does NOT decrement hands_left before scoring — Acrobat/Dusk
-        # check the pre-play value. Use the raw state value.
-        "hands_left": state.get("round", {}).get("hands_left", 1),
-        "joker_limit": state.get("jokers", {}).get("limit", 5),
-        "hand_name": getattr(action, "hand_name", ""),
-        "ancient_suit": state.get("round", {}).get("ancient_suit"),
-        "deck_count": state.get("cards", {}).get("count", 0),
-        "deck_cards": state.get("cards", {}).get("cards", []),
-        "blind_name": snap_blind_name,
-        "ante": state.get("ante_num", 1),
-        "_boss_disabled": state.get("_boss_disabled", False),
-        "_ox_most_played": state.get("round", {}).get("most_played_poker_hand"),
-    }
-
-
-def _detect_joker_changes(gs: GameLoopState, state: dict) -> None:
-    """Detect joker roster changes, log strategy shift, handle Luchador sell."""
-    cur_joker_keys = {j.get("key") for j in state.get("jokers", {}).get("cards", [])}
-    if cur_joker_keys != gs.prev_joker_keys and gs.prev_joker_keys:
-        from balatro_bot.strategy import compute_strategy as _cs
-        new_strat = _cs(state.get("jokers", {}).get("cards", []), state.get("hands", {}))
-        log.info("[STRAT] %s", new_strat.describes())
-        # Luchador sold during a boss blind → boss effect disabled
-        if "j_luchador" in gs.prev_joker_keys and "j_luchador" not in cur_joker_keys:
-            from balatro_bot.domain.policy.playing import BOSS_BLINDS
-            if gs.current_blind_name in BOSS_BLINDS:
-                state["_boss_disabled"] = True
-                log.info("[BOSS] Luchador sold — %s effect disabled", gs.current_blind_name)
-    gs.prev_joker_keys = cur_joker_keys
-
-
-def _log_game_over(gs: GameLoopState, state: dict) -> None:
-    """Log game over summary and handle win capture."""
-    # Capture chips from the final state
-    final_chips = state.get("round", {}).get("chips", 0)
-    if final_chips > gs.max_chips_this_blind:
-        gs.max_chips_this_blind = final_chips
-
-    # Log final round summary if died on a blind
-    _log_blind_result(gs, "LOST")
-
-    ante = state.get("ante_num", "?")
-    round_num = state.get("round_num", "?")
-    seed = state.get("seed", "?")
-    if gs.actually_won:
-        log.info(
-            "Game over: VICTORY (died in endless) | seed=%s ante=%s round=%s | %d actions taken",
-            seed, ante, round_num, gs.actions_taken,
-        )
-    elif state.get("won", False):
-        log.info(
-            "Game over: DEFEAT (state.won=true but never reached ante 9) | seed=%s ante=%s round=%s | %d actions taken",
-            seed, ante, round_num, gs.actions_taken,
-        )
-    else:
-        log.info(
-            "Game over: DEFEAT | seed=%s ante=%s round=%s | %d actions taken",
-            seed, ante, round_num, gs.actions_taken,
-        )
-        _stream_log.info("")
-        _stream_log.info("GAME OVER at Ante %s", ante)
-    joker_names = [j.get("label", "?") for j in state.get("jokers", {}).get("cards", [])]
-    log.info(
-        "Summary: $%d | jokers: [%s] | hands=%d discards=%d",
-        state.get("money", 0),
-        ", ".join(joker_names) if joker_names else "none",
-        gs.total_hands_played, gs.total_discards_used,
-    )
-
-    if _win_handler:
-        if gs.actually_won:
-            _win_handler.flush_win(seed)
-        else:
-            _win_handler.reset()
-
-
-def _log_ante_transition(gs: GameLoopState, state: dict) -> None:
-    """Log roster, strategy, hand levels when ante changes."""
-    ante_num = state.get("ante_num")
-    if ante_num is None or ante_num == gs.last_ante:
-        return
-
-    joker_cards = state.get("jokers", {}).get("cards", [])
-    hand_levels = state.get("hands", {})
-    money = state.get("money", 0)
-
-    # Roster with effect values
-    from balatro_bot.joker_effects import parse_effect_value
-    roster_parts = []
-    for j in joker_cards:
-        label = j.get("label", "?")
-        effect_text = j.get("value", {}).get("effect", "")
-        parsed = parse_effect_value(effect_text) if effect_text else {}
-        if parsed.get("xmult"):
-            roster_parts.append(f"{label}(X{parsed['xmult']:.1f})")
-        elif parsed.get("mult"):
-            roster_parts.append(f"{label}(+{parsed['mult']:.0f}mult)")
-        elif parsed.get("chips"):
-            roster_parts.append(f"{label}(+{parsed['chips']:.0f}chips)")
-        else:
-            roster_parts.append(label)
-
-    log.info(
-        "[ANTE %s] Roster (%d jokers): [%s]",
-        ante_num, len(joker_cards),
-        ", ".join(roster_parts) if roster_parts else "none",
-    )
-
-    deck_cards = state.get("cards", {}).get("cards", [])
-    log.info("[ANTE %s] Deck %s", ante_num, _format_deck_snapshot(deck_cards))
-
-    from balatro_bot.strategy import compute_strategy
-    strat = compute_strategy(joker_cards, hand_levels)
-    log.info("[ANTE %s] Strategy: %s", ante_num, strat.describes())
-
-    leveled = []
-    for ht, data in hand_levels.items():
-        if isinstance(data, dict) and data.get("level", 1) > 1:
-            leveled.append(f"{ht}(lv{data['level']})")
-    if leveled:
-        log.info("[ANTE %s] Money: $%d | Levels: %s", ante_num, money, ", ".join(leveled))
-    else:
-        log.info("[ANTE %s] Money: $%d", ante_num, money)
-
-    _stream_log.info("")
-    _stream_log.info("=== Ante %s / 8 ===", ante_num)
-    joker_names = [j.get("label", "?") for j in joker_cards]
-    _stream_log.info("Jokers: %s", ", ".join(joker_names) if joker_names else "(none)")
-    _stream_log.info("Money: $%d", money)
-
-    gs.last_ante = ante_num
-
-
-def _log_shop_state(gs: GameLoopState, state: dict) -> None:
-    """Log shop inventory when it changes."""
-    shop_cards = state.get("shop", {}).get("cards", [])
-    packs = state.get("packs", {}).get("cards", [])
-    vouchers = state.get("vouchers", {}).get("cards", [])
-    shop_id = tuple(c.get("label", "") for c in shop_cards)
-    if shop_id == gs.last_logged_shop:
-        return
-
-    jokers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                    for c in shop_cards if c.get("set") == "JOKER"]
-    consumables_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                         for c in shop_cards if c.get("set") not in ("JOKER",)]
-    packs_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                   for c in packs]
-    vouchers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                      for c in vouchers]
-    parts = []
-    if jokers_avail:
-        parts.append("jokers: " + ", ".join(jokers_avail))
-    if consumables_avail:
-        parts.append("consumables: " + ", ".join(consumables_avail))
-    if packs_avail:
-        parts.append("packs: " + ", ".join(packs_avail))
-    if vouchers_avail:
-        parts.append("vouchers: " + ", ".join(vouchers_avail))
-    money = state.get("money", 0)
-    log.info("Shop ($%d): %s", money, " | ".join(parts) if parts else "(empty)")
-    gs.last_logged_shop = shop_id
-
-
-def _log_blind_transition(gs: GameLoopState, state: dict) -> None:
-    """Detect blind select changes, log previous blind result, set up new blind tracking."""
-    blinds = state.get("blinds", {})
-    blind_id = tuple(
-        (k, b.get("name", ""), b.get("status", ""))
-        for k, b in blinds.items() if isinstance(b, dict)
-    )
-    if blind_id == gs.last_logged_blind:
-        return
-
-    for key, b in blinds.items():
-        if isinstance(b, dict) and b.get("status") in ("SELECT", "CURRENT"):
-            name = b.get("name", "?")
-            score = b.get("score", "?")
-            # Log previous blind summary before overwriting
-            if gs.current_blind_name and gs.max_chips_this_blind > 0:
-                _log_blind_result(gs, "WON")
-            log.info("Blind: %s (need %s chips)", name, score)
-            _stream_log.info("")
-            _stream_log.info("--- %s — need %s chips ---", name, f"{score:,}" if isinstance(score, int) else score)
-            gs.current_blind_name = name
-            gs.current_blind_target = score
-            gs.max_chips_this_blind = 0
-            state.pop("_boss_disabled", None)
-            gs.hands_at_blind_start = gs.total_hands_played
-            gs.discards_at_blind_start = gs.total_discards_used
-            gs.hand_context_logged = False
-            break
-    gs.last_logged_blind = blind_id
-
-
-def _log_hand_state(gs: GameLoopState, state: dict) -> None:
-    """Log hand composition and first-hand-of-blind context."""
-    hand_cards = state.get("hand", {}).get("cards", [])
-    hand_id = tuple(c.get("label", "") for c in hand_cards)
-    if hand_id == gs.last_logged_hand:
-        return
-
-    hand_str = ", ".join(fmt_card(c) for c in hand_cards)
-    if gs.prev_hand_labels:
-        remaining = list(gs.prev_hand_labels)
-        drew = []
-        for c in hand_cards:
-            lbl = c.get("label", "")
-            if lbl in remaining:
-                remaining.remove(lbl)
-            else:
-                drew.append(fmt_card(c))
-        drew_str = f" | drew: [{', '.join(drew)}]" if drew else ""
-    else:
-        drew_str = ""
-    debuffed = [fmt_card(c) for c in hand_cards
-                if isinstance(c.get("state", {}), dict) and c["state"].get("debuff")]
-    debuff_str = f" | DEBUFFED: [{', '.join(debuffed)}]" if debuffed else ""
-    log.info("Hand: [%s]%s%s", hand_str, drew_str, debuff_str)
-    gs.prev_hand_labels = [c.get("label", "") for c in hand_cards]
-    gs.last_logged_hand = hand_id
-
-    # First hand of a new blind — log context once
-    if not gs.hand_context_logged and gs.current_blind_name:
-        jokers_now = state.get("jokers", {}).get("cards", [])
-        hand_levels_now = state.get("hands", {})
-        rnd = state.get("round", {})
-        from balatro_bot.domain.scoring.search import best_hand as _bh
-        jlimit = state.get("jokers", {}).get("limit", 5)
-        bh = _bh(hand_cards, hand_levels_now, jokers=jokers_now, joker_limit=jlimit)
-        best_score = bh.total if bh else 0
-        best_name = bh.hand_name if bh else "?"
-        blind_need = gs.current_blind_target or 0
-        can_win = best_score >= blind_need if blind_need else False
-        log.info(
-            "[HAND] Best: %s for %s | Blind: %s needs %s | Hands: %d | %s",
-            best_name, f"{best_score:,}", gs.current_blind_name,
-            f"{blind_need:,}" if isinstance(blind_need, int) else blind_need,
-            rnd.get("hands_left", 0),
-            "CAN WIN" if can_win else "NEED MORE",
-        )
-        _stream_log.info(
-            "Best: %s for %s | Hands: %d | %s",
-            best_name, f"{best_score:,}",
-            rnd.get("hands_left", 0),
-            "CAN WIN" if can_win else "NEED MORE",
-        )
-        gs.hand_context_logged = True
-
+# ---------------------------------------------------------------------------
+# Main game loop
+# ---------------------------------------------------------------------------
 
 def run_bot(
     client: BalatroClient,
@@ -899,6 +215,12 @@ def run_bot(
     stream_delay: float = 0.0,
 ) -> bool:
     """Main bot loop. Returns True if the game was won."""
+    from balatro_bot.bot_logging import (
+        build_play_snapshot, detect_joker_changes, log_action,
+        log_ante_transition, log_blind_transition, log_game_over,
+        log_hand_state, log_played_hand, log_shop_state,
+    )
+
     if start_game:
         try:
             client.call("menu")
@@ -945,7 +267,7 @@ def run_bot(
                 )
             gs.won_logged = True
 
-        _log_ante_transition(gs, state)
+        log_ante_transition(gs, state)
         # Track highest chips seen during this blind (capture before round resets)
         cur_chips = state.get("round", {}).get("chips", 0)
         if cur_chips > gs.max_chips_this_blind:
@@ -966,16 +288,16 @@ def run_bot(
             gs.last_logged_shop = None
 
         if game_state == "SHOP":
-            _log_shop_state(gs, state)
+            log_shop_state(gs, state)
 
         if game_state == "BLIND_SELECT":
-            _log_blind_transition(gs, state)
+            log_blind_transition(gs, state)
 
         if game_state != "BLIND_SELECT":
             gs.last_logged_blind = None
 
         if game_state == "SELECTING_HAND":
-            _log_hand_state(gs, state)
+            log_hand_state(gs, state)
 
         # Refresh state before deciding — previous action response may have
         # stale money, joker counters, or debuff flags.
@@ -1011,8 +333,8 @@ def run_bot(
                 except Exception:
                     log.warning("rearrange failed, playing in original order")
 
-        card_detail = _format_card_detail(method, params, state)
-        _log_action(gs, game_state, method, params, action, card_detail, state)
+        card_detail = format_card_detail(method, params, state)
+        log_action(gs, game_state, method, params, action, card_detail, state)
 
         # Stream mode: highlight cards one at a time before playing/discarding
         if stream_delay > 0 and method in ("play", "discard") and params and "cards" in params:
@@ -1028,7 +350,7 @@ def run_bot(
         if method == "play":
             pre_play_chips = state.get("round", {}).get("chips", 0)
             _scoring_log.info("  PRE_PLAY chips_in_round=%d", pre_play_chips)
-            play_snapshot = _build_play_snapshot(state, params, action)
+            play_snapshot = build_play_snapshot(state, params, action)
 
         # Capture expected hand score for chip accounting on timeout
         expected_hand_score = 0
@@ -1060,11 +382,11 @@ def run_bot(
                 # cards are replenished).  The pre-play snapshot is used
                 # as-is; joker corrections (Ramen, Yorick, Green Joker)
                 # are applied in joker_effects/complex.py.
-                _log_played_hand(play_snapshot, pre_play_chips, state, fmt_card)
+                log_played_hand(play_snapshot, pre_play_chips, state)
             elif method == "discard":
                 gs.total_discards_used += 1
 
-            _detect_joker_changes(gs, state)
+            detect_joker_changes(gs, state)
 
             gs.consecutive_errors = 0
 
@@ -1136,5 +458,5 @@ def run_bot(
             if saved_timeout is not None:
                 client.timeout = saved_timeout
 
-    _log_game_over(gs, state)
+    log_game_over(gs, state)
     return gs.actually_won

--- a/src/balatro_bot/bot.py
+++ b/src/balatro_bot/bot.py
@@ -775,6 +775,16 @@ def run_bot(
             indices = params["cards"]
             labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
             card_detail = f" [{', '.join(labels)}]"
+        elif method == "use" and params and "cards" in params:
+            hand_cards = state.get("hand", {}).get("cards", [])
+            indices = params["cards"]
+            labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+            card_detail = f" targets:[{', '.join(labels)}]"
+        elif method == "pack" and params and "targets" in params:
+            hand_cards = state.get("hand", {}).get("cards", [])
+            indices = params["targets"]
+            labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+            card_detail = f" targets:[{', '.join(labels)}]"
 
         log.info(
             "[#%d] %s -> %s(%s)%s | %s",

--- a/src/balatro_bot/bot.py
+++ b/src/balatro_bot/bot.py
@@ -9,6 +9,8 @@ import re
 import string
 import time
 from collections import defaultdict
+from dataclasses import dataclass, field
+
 import httpx
 from balatrobot import APIError, BalatroClient
 
@@ -16,6 +18,45 @@ from balatro_bot.engine import RuleEngine
 
 log = logging.getLogger("balatro_bot")
 _stream_log = logging.getLogger("balatro_stream")
+
+# Card formatting constants (used throughout the game loop)
+SUIT_SYM = {"H": "\u2665", "D": "\u2666", "C": "\u2663", "S": "\u2660"}
+RANK_SYM = {
+    "2": "2", "3": "3", "4": "4", "5": "5", "6": "6",
+    "7": "7", "8": "8", "9": "9", "T": "10",
+    "J": "J", "Q": "Q", "K": "K", "A": "A",
+}
+
+
+def fmt_card(c: dict) -> str:
+    """Format a card dict as a compact label like '10♥' or 'A♠'."""
+    val = c.get("value", {})
+    return RANK_SYM.get(val.get("rank", ""), "?") + SUIT_SYM.get(val.get("suit", ""), "?")
+
+
+@dataclass
+class GameLoopState:
+    """Mutable state tracked across the game loop in run_bot()."""
+
+    actions_taken: int = 0
+    consecutive_errors: int = 0
+    total_hands_played: int = 0
+    total_discards_used: int = 0
+    hands_at_blind_start: int = 0
+    discards_at_blind_start: int = 0
+    last_logged_hand: tuple | None = None
+    last_logged_shop: tuple | None = None
+    last_logged_blind: tuple | None = None
+    prev_joker_keys: set = field(default_factory=set)
+    hand_context_logged: bool = False
+    prev_hand_labels: list = field(default_factory=list)
+    last_ante: int | None = None
+    last_round: int | None = None
+    current_blind_name: str | None = None
+    current_blind_target: int | str | None = None
+    max_chips_this_blind: int = 0
+    won_logged: bool = False
+    actually_won: bool = False
 
 
 class WinCaptureHandler(logging.handlers.MemoryHandler):
@@ -433,6 +474,419 @@ def _format_deck_snapshot(deck_cards: list) -> str:
     return f"({total}): " + " ".join(parts)
 
 
+def _find_current_blind(state: dict) -> tuple[str, int | str] | None:
+    """Find the current/selected blind from game state. Returns (name, score) or None."""
+    for b in state.get("blinds", {}).values():
+        if isinstance(b, dict) and b.get("status") == "CURRENT":
+            return b.get("name", "?"), b.get("score", "?")
+    for b in state.get("blinds", {}).values():
+        if isinstance(b, dict) and b.get("status") == "SELECT":
+            return b.get("name", "?"), b.get("score", "?")
+    return None
+
+
+def _check_victory(
+    gs: GameLoopState, state: dict,
+    pre_play_chips: int = 0, expected_hand_score: int = 0,
+) -> bool:
+    """Detect ante 9+ victory. Returns True if newly detected."""
+    ante = state.get("ante_num", 0)
+    if ante < 9 or gs.actually_won:
+        return False
+
+    gs.actually_won = True
+
+    if pre_play_chips or expected_hand_score:
+        # Timeout victory — estimate final chips from pre-play + expected score
+        if gs.current_blind_name:
+            target = gs.current_blind_target if isinstance(gs.current_blind_target, int) else 0
+            final_chips = pre_play_chips + expected_hand_score
+            gs.max_chips_this_blind = max(gs.max_chips_this_blind, final_chips)
+            log.info(
+                "VICTORY at ante %s round %s (seed=%s) — scored %s / needed %s — WON | %d hands, %d discards",
+                ante, state.get("round_num", "?"), state.get("seed", "?"),
+                f"{final_chips:,}", f"{target:,}",
+                gs.total_hands_played - gs.hands_at_blind_start,
+                gs.total_discards_used - gs.discards_at_blind_start,
+            )
+        else:
+            log.info(
+                "VICTORY at ante %s round %s (seed=%s)",
+                ante, state.get("round_num", "?"), state.get("seed", "?"),
+            )
+    else:
+        # Normal victory — log to both loggers
+        log.info(
+            "VICTORY at ante %s round %s (seed=%s) — entering endless mode",
+            ante, state.get("round_num", "?"), state.get("seed", "?"),
+        )
+        _stream_log.info("")
+        _stream_log.info("*** VICTORY! ***")
+        _log_blind_result(gs, "WON")
+
+    gs.current_blind_name = None
+    return True
+
+
+def _log_blind_result(gs: GameLoopState, result: str = "WON") -> None:
+    """Log round summary for the current blind, then clear current_blind_name."""
+    if not gs.current_blind_name:
+        return
+    target_str = (
+        f"{gs.current_blind_target:,}"
+        if isinstance(gs.current_blind_target, int)
+        else gs.current_blind_target
+    )
+    hands_used = gs.total_hands_played - gs.hands_at_blind_start
+    discards_used = gs.total_discards_used - gs.discards_at_blind_start
+    log.info(
+        "[ROUND] %s: scored %s / needed %s — %s | %d hands, %d discards",
+        gs.current_blind_name, f"{gs.max_chips_this_blind:,}",
+        target_str, result, hands_used, discards_used,
+    )
+    if result == "WON":
+        _stream_log.info(
+            "%s WON — %s / %s | %d hands, %d discards",
+            gs.current_blind_name, f"{gs.max_chips_this_blind:,}",
+            target_str, hands_used, discards_used,
+        )
+
+
+def _format_card_detail(method: str, params: dict | None, state: dict) -> str:
+    """Build card detail string for action logging."""
+    if method in ("play", "discard") and "cards" in (params or {}):
+        hand_cards = state.get("hand", {}).get("cards", [])
+        indices = params["cards"]
+        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+        return f" [{', '.join(labels)}]"
+    if method == "use" and params and "cards" in params:
+        hand_cards = state.get("hand", {}).get("cards", [])
+        indices = params["cards"]
+        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+        return f" targets:[{', '.join(labels)}]"
+    if method == "pack" and params and "targets" in params:
+        hand_cards = state.get("hand", {}).get("cards", [])
+        indices = params["targets"]
+        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+        return f" targets:[{', '.join(labels)}]"
+    return ""
+
+
+def _log_action(
+    gs: GameLoopState, game_state: str, method: str, params: dict | None,
+    action: object, card_detail: str, state: dict,
+) -> None:
+    """Log action to both main and stream loggers."""
+    log.info(
+        "[#%d] %s -> %s(%s)%s | %s",
+        gs.actions_taken, game_state, method, params or "",
+        card_detail, getattr(action, "reason", ""),
+    )
+
+    reason = getattr(action, "reason", "")
+    if method == "play" and card_detail:
+        if reason.startswith("milk:"):
+            _stream_log.info("Milk: %s", reason[5:].strip())
+        else:
+            score_m = re.search(r"for (\d+)", reason)
+            hand_name_str = getattr(action, "hand_name", "") or "?"
+            score_str = f"{int(score_m.group(1)):,}" if score_m else "?"
+            chips_remaining = state.get("round", {}).get("chips", 0)
+            blind_need = gs.current_blind_target if isinstance(gs.current_blind_target, int) else 0
+            remaining = blind_need - chips_remaining if blind_need else 0
+            _stream_log.info(
+                "Play %s → %s / %s needed",
+                hand_name_str, score_str,
+                f"{remaining:,}" if remaining > 0 else "0",
+            )
+    elif method == "discard" and card_detail:
+        chase_m = re.search(r"chase (\w[\w ]*?) \((\d+)%", reason) if reason else None
+        if chase_m:
+            _stream_log.info(
+                "Discard — chasing %s (%s%%)",
+                chase_m.group(1), chase_m.group(2),
+            )
+        else:
+            _stream_log.info("Discard")
+    elif method == "buy":
+        _stream_log.info("Bought: %s", reason.split("(")[0].strip() if reason else "?")
+    elif method == "next_round":
+        _stream_log.info("")
+
+
+def _build_play_snapshot(state: dict, params: dict, action: object) -> dict:
+    """Build the pre-play snapshot dict for scoring diagnostics."""
+    hand_cards_snap = state.get("hand", {}).get("cards", [])
+    play_indices = set(params.get("cards", []))
+
+    # Detect The Flint and halve hand levels for accurate scoring
+    snap_hand_levels = state.get("hands", {})
+    if not state.get("_boss_disabled", False):
+        blind_info = _find_current_blind(state)
+        if blind_info and blind_info[0] == "The Flint":
+            from balatro_bot.domain.scoring.base import flint_halve_hand_levels
+            snap_hand_levels = flint_halve_hand_levels(snap_hand_levels)
+
+    blind_info = _find_current_blind(state)
+    snap_blind_name = blind_info[0] if blind_info else ""
+
+    return {
+        "played": [hand_cards_snap[i] for i in sorted(params.get("cards", [])) if i < len(hand_cards_snap)],
+        "held": [c for j, c in enumerate(hand_cards_snap) if j not in play_indices],
+        "jokers": state.get("jokers", {}).get("cards", []),
+        "hand_levels": snap_hand_levels,
+        "money": state.get("money", 0),
+        "discards_left": state.get("round", {}).get("discards_left", 0),
+        # Game does NOT decrement hands_left before scoring — Acrobat/Dusk
+        # check the pre-play value. Use the raw state value.
+        "hands_left": state.get("round", {}).get("hands_left", 1),
+        "joker_limit": state.get("jokers", {}).get("limit", 5),
+        "hand_name": getattr(action, "hand_name", ""),
+        "ancient_suit": state.get("round", {}).get("ancient_suit"),
+        "deck_count": state.get("cards", {}).get("count", 0),
+        "deck_cards": state.get("cards", {}).get("cards", []),
+        "blind_name": snap_blind_name,
+        "ante": state.get("ante_num", 1),
+        "_boss_disabled": state.get("_boss_disabled", False),
+        "_ox_most_played": state.get("round", {}).get("most_played_poker_hand"),
+    }
+
+
+def _detect_joker_changes(gs: GameLoopState, state: dict) -> None:
+    """Detect joker roster changes, log strategy shift, handle Luchador sell."""
+    cur_joker_keys = {j.get("key") for j in state.get("jokers", {}).get("cards", [])}
+    if cur_joker_keys != gs.prev_joker_keys and gs.prev_joker_keys:
+        from balatro_bot.strategy import compute_strategy as _cs
+        new_strat = _cs(state.get("jokers", {}).get("cards", []), state.get("hands", {}))
+        log.info("[STRAT] %s", new_strat.describes())
+        # Luchador sold during a boss blind → boss effect disabled
+        if "j_luchador" in gs.prev_joker_keys and "j_luchador" not in cur_joker_keys:
+            from balatro_bot.domain.policy.playing import BOSS_BLINDS
+            if gs.current_blind_name in BOSS_BLINDS:
+                state["_boss_disabled"] = True
+                log.info("[BOSS] Luchador sold — %s effect disabled", gs.current_blind_name)
+    gs.prev_joker_keys = cur_joker_keys
+
+
+def _log_game_over(gs: GameLoopState, state: dict) -> None:
+    """Log game over summary and handle win capture."""
+    # Capture chips from the final state
+    final_chips = state.get("round", {}).get("chips", 0)
+    if final_chips > gs.max_chips_this_blind:
+        gs.max_chips_this_blind = final_chips
+
+    # Log final round summary if died on a blind
+    _log_blind_result(gs, "LOST")
+
+    ante = state.get("ante_num", "?")
+    round_num = state.get("round_num", "?")
+    seed = state.get("seed", "?")
+    if gs.actually_won:
+        log.info(
+            "Game over: VICTORY (died in endless) | seed=%s ante=%s round=%s | %d actions taken",
+            seed, ante, round_num, gs.actions_taken,
+        )
+    elif state.get("won", False):
+        log.info(
+            "Game over: DEFEAT (state.won=true but never reached ante 9) | seed=%s ante=%s round=%s | %d actions taken",
+            seed, ante, round_num, gs.actions_taken,
+        )
+    else:
+        log.info(
+            "Game over: DEFEAT | seed=%s ante=%s round=%s | %d actions taken",
+            seed, ante, round_num, gs.actions_taken,
+        )
+        _stream_log.info("")
+        _stream_log.info("GAME OVER at Ante %s", ante)
+    joker_names = [j.get("label", "?") for j in state.get("jokers", {}).get("cards", [])]
+    log.info(
+        "Summary: $%d | jokers: [%s] | hands=%d discards=%d",
+        state.get("money", 0),
+        ", ".join(joker_names) if joker_names else "none",
+        gs.total_hands_played, gs.total_discards_used,
+    )
+
+    if _win_handler:
+        if gs.actually_won:
+            _win_handler.flush_win(seed)
+        else:
+            _win_handler.reset()
+
+
+def _log_ante_transition(gs: GameLoopState, state: dict) -> None:
+    """Log roster, strategy, hand levels when ante changes."""
+    ante_num = state.get("ante_num")
+    if ante_num is None or ante_num == gs.last_ante:
+        return
+
+    joker_cards = state.get("jokers", {}).get("cards", [])
+    hand_levels = state.get("hands", {})
+    money = state.get("money", 0)
+
+    # Roster with effect values
+    from balatro_bot.joker_effects import parse_effect_value
+    roster_parts = []
+    for j in joker_cards:
+        label = j.get("label", "?")
+        effect_text = j.get("value", {}).get("effect", "")
+        parsed = parse_effect_value(effect_text) if effect_text else {}
+        if parsed.get("xmult"):
+            roster_parts.append(f"{label}(X{parsed['xmult']:.1f})")
+        elif parsed.get("mult"):
+            roster_parts.append(f"{label}(+{parsed['mult']:.0f}mult)")
+        elif parsed.get("chips"):
+            roster_parts.append(f"{label}(+{parsed['chips']:.0f}chips)")
+        else:
+            roster_parts.append(label)
+
+    log.info(
+        "[ANTE %s] Roster (%d jokers): [%s]",
+        ante_num, len(joker_cards),
+        ", ".join(roster_parts) if roster_parts else "none",
+    )
+
+    deck_cards = state.get("cards", {}).get("cards", [])
+    log.info("[ANTE %s] Deck %s", ante_num, _format_deck_snapshot(deck_cards))
+
+    from balatro_bot.strategy import compute_strategy
+    strat = compute_strategy(joker_cards, hand_levels)
+    log.info("[ANTE %s] Strategy: %s", ante_num, strat.describes())
+
+    leveled = []
+    for ht, data in hand_levels.items():
+        if isinstance(data, dict) and data.get("level", 1) > 1:
+            leveled.append(f"{ht}(lv{data['level']})")
+    if leveled:
+        log.info("[ANTE %s] Money: $%d | Levels: %s", ante_num, money, ", ".join(leveled))
+    else:
+        log.info("[ANTE %s] Money: $%d", ante_num, money)
+
+    _stream_log.info("")
+    _stream_log.info("=== Ante %s / 8 ===", ante_num)
+    joker_names = [j.get("label", "?") for j in joker_cards]
+    _stream_log.info("Jokers: %s", ", ".join(joker_names) if joker_names else "(none)")
+    _stream_log.info("Money: $%d", money)
+
+    gs.last_ante = ante_num
+
+
+def _log_shop_state(gs: GameLoopState, state: dict) -> None:
+    """Log shop inventory when it changes."""
+    shop_cards = state.get("shop", {}).get("cards", [])
+    packs = state.get("packs", {}).get("cards", [])
+    vouchers = state.get("vouchers", {}).get("cards", [])
+    shop_id = tuple(c.get("label", "") for c in shop_cards)
+    if shop_id == gs.last_logged_shop:
+        return
+
+    jokers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                    for c in shop_cards if c.get("set") == "JOKER"]
+    consumables_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                         for c in shop_cards if c.get("set") not in ("JOKER",)]
+    packs_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                   for c in packs]
+    vouchers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                      for c in vouchers]
+    parts = []
+    if jokers_avail:
+        parts.append("jokers: " + ", ".join(jokers_avail))
+    if consumables_avail:
+        parts.append("consumables: " + ", ".join(consumables_avail))
+    if packs_avail:
+        parts.append("packs: " + ", ".join(packs_avail))
+    if vouchers_avail:
+        parts.append("vouchers: " + ", ".join(vouchers_avail))
+    money = state.get("money", 0)
+    log.info("Shop ($%d): %s", money, " | ".join(parts) if parts else "(empty)")
+    gs.last_logged_shop = shop_id
+
+
+def _log_blind_transition(gs: GameLoopState, state: dict) -> None:
+    """Detect blind select changes, log previous blind result, set up new blind tracking."""
+    blinds = state.get("blinds", {})
+    blind_id = tuple(
+        (k, b.get("name", ""), b.get("status", ""))
+        for k, b in blinds.items() if isinstance(b, dict)
+    )
+    if blind_id == gs.last_logged_blind:
+        return
+
+    for key, b in blinds.items():
+        if isinstance(b, dict) and b.get("status") in ("SELECT", "CURRENT"):
+            name = b.get("name", "?")
+            score = b.get("score", "?")
+            # Log previous blind summary before overwriting
+            if gs.current_blind_name and gs.max_chips_this_blind > 0:
+                _log_blind_result(gs, "WON")
+            log.info("Blind: %s (need %s chips)", name, score)
+            _stream_log.info("")
+            _stream_log.info("--- %s — need %s chips ---", name, f"{score:,}" if isinstance(score, int) else score)
+            gs.current_blind_name = name
+            gs.current_blind_target = score
+            gs.max_chips_this_blind = 0
+            state.pop("_boss_disabled", None)
+            gs.hands_at_blind_start = gs.total_hands_played
+            gs.discards_at_blind_start = gs.total_discards_used
+            gs.hand_context_logged = False
+            break
+    gs.last_logged_blind = blind_id
+
+
+def _log_hand_state(gs: GameLoopState, state: dict) -> None:
+    """Log hand composition and first-hand-of-blind context."""
+    hand_cards = state.get("hand", {}).get("cards", [])
+    hand_id = tuple(c.get("label", "") for c in hand_cards)
+    if hand_id == gs.last_logged_hand:
+        return
+
+    hand_str = ", ".join(fmt_card(c) for c in hand_cards)
+    if gs.prev_hand_labels:
+        remaining = list(gs.prev_hand_labels)
+        drew = []
+        for c in hand_cards:
+            lbl = c.get("label", "")
+            if lbl in remaining:
+                remaining.remove(lbl)
+            else:
+                drew.append(fmt_card(c))
+        drew_str = f" | drew: [{', '.join(drew)}]" if drew else ""
+    else:
+        drew_str = ""
+    debuffed = [fmt_card(c) for c in hand_cards
+                if isinstance(c.get("state", {}), dict) and c["state"].get("debuff")]
+    debuff_str = f" | DEBUFFED: [{', '.join(debuffed)}]" if debuffed else ""
+    log.info("Hand: [%s]%s%s", hand_str, drew_str, debuff_str)
+    gs.prev_hand_labels = [c.get("label", "") for c in hand_cards]
+    gs.last_logged_hand = hand_id
+
+    # First hand of a new blind — log context once
+    if not gs.hand_context_logged and gs.current_blind_name:
+        jokers_now = state.get("jokers", {}).get("cards", [])
+        hand_levels_now = state.get("hands", {})
+        rnd = state.get("round", {})
+        from balatro_bot.domain.scoring.search import best_hand as _bh
+        jlimit = state.get("jokers", {}).get("limit", 5)
+        bh = _bh(hand_cards, hand_levels_now, jokers=jokers_now, joker_limit=jlimit)
+        best_score = bh.total if bh else 0
+        best_name = bh.hand_name if bh else "?"
+        blind_need = gs.current_blind_target or 0
+        can_win = best_score >= blind_need if blind_need else False
+        log.info(
+            "[HAND] Best: %s for %s | Blind: %s needs %s | Hands: %d | %s",
+            best_name, f"{best_score:,}", gs.current_blind_name,
+            f"{blind_need:,}" if isinstance(blind_need, int) else blind_need,
+            rnd.get("hands_left", 0),
+            "CAN WIN" if can_win else "NEED MORE",
+        )
+        _stream_log.info(
+            "Best: %s for %s | Hands: %d | %s",
+            best_name, f"{best_score:,}",
+            rnd.get("hands_left", 0),
+            "CAN WIN" if can_win else "NEED MORE",
+        )
+        gs.hand_context_logged = True
+
+
 def run_bot(
     client: BalatroClient,
     engine: RuleEngine,
@@ -472,37 +926,7 @@ def run_bot(
         state = client.call("gamestate")
         log.info("Joined existing game: state=%s", state.get("state"))
 
-    actions_taken = 0
-    consecutive_errors = 0
-    total_hands_played = 0
-    total_discards_used = 0
-    hands_at_blind_start = 0
-    discards_at_blind_start = 0
-    last_logged_hand = None
-    last_logged_shop = None
-    last_logged_blind = None
-    prev_joker_keys: set[str] = set()
-    hand_context_logged = False
-    prev_hand_labels: list[str] = []
-    last_ante = None
-    last_round = None
-    current_blind_name = None
-    current_blind_target = None
-    max_chips_this_blind = 0
-
-    SUIT_SYM = {"H": "\u2665", "D": "\u2666", "C": "\u2663", "S": "\u2660"}
-    RANK_SYM = {
-        "2": "2", "3": "3", "4": "4", "5": "5", "6": "6",
-        "7": "7", "8": "8", "9": "9", "T": "10",
-        "J": "J", "Q": "Q", "K": "K", "A": "A",
-    }
-
-    def fmt_card(c: dict) -> str:
-        val = c.get("value", {})
-        return RANK_SYM.get(val.get("rank", ""), "?") + SUIT_SYM.get(val.get("suit", ""), "?")
-
-    won_logged = False
-    actually_won = False  # True only when bot reaches ante 9+ (beat the ante 8 boss)
+    gs = GameLoopState()
 
     while state.get("state") != "GAME_OVER":
         game_state = state.get("state", "")
@@ -510,230 +934,48 @@ def run_bot(
         # Detect real win: bot advanced past ante 8 (beat the boss)
         # Don't trust state.won — Hieroglyph voucher inflates ante counter
         cur_ante = state.get("ante_num", 0)
-        if cur_ante >= 9 and not actually_won:
-            actually_won = True
-            log.info(
-                "VICTORY at ante %s round %s (seed=%s) — entering endless mode",
-                cur_ante, state.get("round_num", "?"),
-                state.get("seed", "?"),
-            )
-            _stream_log.info("")
-            _stream_log.info("*** VICTORY! ***")
-            if current_blind_name:
-                target = current_blind_target if isinstance(current_blind_target, int) else 0
-                log.info(
-                    "[ROUND] %s: scored %s / needed %s — WON | %d hands, %d discards",
-                    current_blind_name, f"{max_chips_this_blind:,}",
-                    f"{target:,}",
-                    total_hands_played - hands_at_blind_start,
-                    total_discards_used - discards_at_blind_start,
-                )
-                current_blind_name = None
+        _check_victory(gs, state)
 
         # Log when state.won fires (may be premature due to Hieroglyph)
-        if state.get("won") and not won_logged:
-            if not actually_won:
+        if state.get("won") and not gs.won_logged:
+            if not gs.actually_won:
                 log.info(
                     "state.won=true at ante %s (Hieroglyph?) — not a real win until ante 9+",
                     state.get("ante_num", "?"),
                 )
-            won_logged = True
+            gs.won_logged = True
 
-        ante_num = state.get("ante_num")
-        round_num = state.get("round_num")
-        if ante_num is not None and ante_num != last_ante:
-            joker_cards = state.get("jokers", {}).get("cards", [])
-            hand_levels = state.get("hands", {})
-            money = state.get("money", 0)
-
-            # Roster with effect values
-            roster_parts = []
-            for j in joker_cards:
-                label = j.get("label", "?")
-                effect_text = j.get("value", {}).get("effect", "")
-                # Extract compact value from effect text
-                from balatro_bot.joker_effects import parse_effect_value
-                parsed = parse_effect_value(effect_text) if effect_text else {}
-                if parsed.get("xmult"):
-                    roster_parts.append(f"{label}(X{parsed['xmult']:.1f})")
-                elif parsed.get("mult"):
-                    roster_parts.append(f"{label}(+{parsed['mult']:.0f}mult)")
-                elif parsed.get("chips"):
-                    roster_parts.append(f"{label}(+{parsed['chips']:.0f}chips)")
-                else:
-                    roster_parts.append(label)
-
-            log.info(
-                "[ANTE %s] Roster (%d jokers): [%s]",
-                ante_num, len(joker_cards),
-                ", ".join(roster_parts) if roster_parts else "none",
-            )
-
-            deck_cards = state.get("cards", {}).get("cards", [])
-            log.info("[ANTE %s] Deck %s", ante_num, _format_deck_snapshot(deck_cards))
-
-            # Strategy snapshot
-            from balatro_bot.strategy import compute_strategy
-            strat = compute_strategy(joker_cards, hand_levels)
-            log.info("[ANTE %s] Strategy: %s", ante_num, strat.describes())
-
-            # Hand levels (only leveled-up hands)
-            leveled = []
-            for ht, data in hand_levels.items():
-                if isinstance(data, dict) and data.get("level", 1) > 1:
-                    leveled.append(f"{ht}(lv{data['level']})")
-            if leveled:
-                log.info("[ANTE %s] Money: $%d | Levels: %s", ante_num, money, ", ".join(leveled))
-            else:
-                log.info("[ANTE %s] Money: $%d", ante_num, money)
-
-            # Stream log — ante summary
-            _stream_log.info("")
-            _stream_log.info("=== Ante %s / 8 ===", ante_num)
-            joker_names = [j.get("label", "?") for j in joker_cards]
-            _stream_log.info("Jokers: %s", ", ".join(joker_names) if joker_names else "(none)")
-            _stream_log.info("Money: $%d", money)
-
-            last_ante = ante_num
+        _log_ante_transition(gs, state)
         # Track highest chips seen during this blind (capture before round resets)
         cur_chips = state.get("round", {}).get("chips", 0)
-        if cur_chips > max_chips_this_blind:
-            max_chips_this_blind = cur_chips
-        last_round = round_num
+        if cur_chips > gs.max_chips_this_blind:
+            gs.max_chips_this_blind = cur_chips
+        gs.last_round = state.get("round_num")
 
         if game_state in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "SPLASH", "TUTORIAL"):
-            last_logged_hand = None
+            gs.last_logged_hand = None
             time.sleep(poll_interval)
             state = client.call("gamestate")
             continue
 
         if game_state != "SELECTING_HAND":
-            last_logged_hand = None
-            prev_hand_labels = []
+            gs.last_logged_hand = None
+            gs.prev_hand_labels = []
 
         if game_state != "SHOP":
-            last_logged_shop = None
+            gs.last_logged_shop = None
 
         if game_state == "SHOP":
-            shop_cards = state.get("shop", {}).get("cards", [])
-            packs = state.get("packs", {}).get("cards", [])
-            vouchers = state.get("vouchers", {}).get("cards", [])
-            shop_id = tuple(c.get("label", "") for c in shop_cards)
-            if shop_id != last_logged_shop:
-                jokers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                                for c in shop_cards if c.get("set") == "JOKER"]
-                consumables_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                                     for c in shop_cards if c.get("set") not in ("JOKER",)]
-                packs_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                               for c in packs]
-                vouchers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
-                                  for c in vouchers]
-                parts = []
-                if jokers_avail:
-                    parts.append("jokers: " + ", ".join(jokers_avail))
-                if consumables_avail:
-                    parts.append("consumables: " + ", ".join(consumables_avail))
-                if packs_avail:
-                    parts.append("packs: " + ", ".join(packs_avail))
-                if vouchers_avail:
-                    parts.append("vouchers: " + ", ".join(vouchers_avail))
-                money = state.get("money", 0)
-                log.info("Shop ($%d): %s", money, " | ".join(parts) if parts else "(empty)")
-                last_logged_shop = shop_id
+            _log_shop_state(gs, state)
 
         if game_state == "BLIND_SELECT":
-            blinds = state.get("blinds", {})
-            blind_id = tuple(
-                (k, b.get("name", ""), b.get("status", ""))
-                for k, b in blinds.items() if isinstance(b, dict)
-            )
-            if blind_id != last_logged_blind:
-                for key, b in blinds.items():
-                    if isinstance(b, dict) and b.get("status") in ("SELECT", "CURRENT"):
-                        name = b.get("name", "?")
-                        score = b.get("score", "?")
-                        # Log previous blind summary before overwriting
-                        if current_blind_name and max_chips_this_blind > 0:
-                            log.info(
-                                "[ROUND] %s: scored %s / needed %s — WON | %d hands, %d discards",
-                                current_blind_name, f"{max_chips_this_blind:,}",
-                                f"{current_blind_target:,}" if isinstance(current_blind_target, int) else current_blind_target,
-                                total_hands_played - hands_at_blind_start,
-                                total_discards_used - discards_at_blind_start,
-                            )
-                            _stream_log.info(
-                                "%s WON — %s / %s | %d hands, %d discards",
-                                current_blind_name, f"{max_chips_this_blind:,}",
-                                f"{current_blind_target:,}" if isinstance(current_blind_target, int) else current_blind_target,
-                                total_hands_played - hands_at_blind_start,
-                                total_discards_used - discards_at_blind_start,
-                            )
-                        log.info("Blind: %s (need %s chips)", name, score)
-                        _stream_log.info("")
-                        _stream_log.info("--- %s — need %s chips ---", name, f"{score:,}" if isinstance(score, int) else score)
-                        current_blind_name = name
-                        current_blind_target = score
-                        max_chips_this_blind = 0
-                        state.pop("_boss_disabled", None)
-                        hands_at_blind_start = total_hands_played
-                        discards_at_blind_start = total_discards_used
-                        hand_context_logged = False
-                        break
-                last_logged_blind = blind_id
+            _log_blind_transition(gs, state)
 
         if game_state != "BLIND_SELECT":
-            last_logged_blind = None
+            gs.last_logged_blind = None
 
         if game_state == "SELECTING_HAND":
-            hand_cards = state.get("hand", {}).get("cards", [])
-            hand_id = tuple(c.get("label", "") for c in hand_cards)
-            if hand_id != last_logged_hand:
-                hand_str = ", ".join(fmt_card(c) for c in hand_cards)
-                if prev_hand_labels:
-                    remaining = list(prev_hand_labels)
-                    drew = []
-                    for c in hand_cards:
-                        lbl = c.get("label", "")
-                        if lbl in remaining:
-                            remaining.remove(lbl)
-                        else:
-                            drew.append(fmt_card(c))
-                    drew_str = f" | drew: [{', '.join(drew)}]" if drew else ""
-                else:
-                    drew_str = ""
-                debuffed = [fmt_card(c) for c in hand_cards
-                            if isinstance(c.get("state", {}), dict) and c["state"].get("debuff")]
-                debuff_str = f" | DEBUFFED: [{', '.join(debuffed)}]" if debuffed else ""
-                log.info("Hand: [%s]%s%s", hand_str, drew_str, debuff_str)
-                prev_hand_labels = [c.get("label", "") for c in hand_cards]
-                last_logged_hand = hand_id
-
-                # First hand of a new blind — log context once
-                if not hand_context_logged and current_blind_name:
-                    jokers_now = state.get("jokers", {}).get("cards", [])
-                    hand_levels_now = state.get("hands", {})
-                    rnd = state.get("round", {})
-                    from balatro_bot.domain.scoring.search import best_hand as _bh
-                    jlimit = state.get("jokers", {}).get("limit", 5)
-                    bh = _bh(hand_cards, hand_levels_now, jokers=jokers_now, joker_limit=jlimit)
-                    best_score = bh.total if bh else 0
-                    best_name = bh.hand_name if bh else "?"
-                    blind_need = current_blind_target or 0
-                    can_win = best_score >= blind_need if blind_need else False
-                    log.info(
-                        "[HAND] Best: %s for %s | Blind: %s needs %s | Hands: %d | %s",
-                        best_name, f"{best_score:,}", current_blind_name,
-                        f"{blind_need:,}" if isinstance(blind_need, int) else blind_need,
-                        rnd.get("hands_left", 0),
-                        "CAN WIN" if can_win else "NEED MORE",
-                    )
-                    _stream_log.info(
-                        "Best: %s for %s | Hands: %d | %s",
-                        best_name, f"{best_score:,}",
-                        rnd.get("hands_left", 0),
-                        "CAN WIN" if can_win else "NEED MORE",
-                    )
-                    hand_context_logged = True
+            _log_hand_state(gs, state)
 
         # Refresh state before deciding — previous action response may have
         # stale money, joker counters, or debuff flags.
@@ -769,66 +1011,8 @@ def run_bot(
                 except Exception:
                     log.warning("rearrange failed, playing in original order")
 
-        card_detail = ""
-        if method in ("play", "discard") and "cards" in (params or {}):
-            hand_cards = state.get("hand", {}).get("cards", [])
-            indices = params["cards"]
-            labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
-            card_detail = f" [{', '.join(labels)}]"
-        elif method == "use" and params and "cards" in params:
-            hand_cards = state.get("hand", {}).get("cards", [])
-            indices = params["cards"]
-            labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
-            card_detail = f" targets:[{', '.join(labels)}]"
-        elif method == "pack" and params and "targets" in params:
-            hand_cards = state.get("hand", {}).get("cards", [])
-            indices = params["targets"]
-            labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
-            card_detail = f" targets:[{', '.join(labels)}]"
-
-        log.info(
-            "[#%d] %s -> %s(%s)%s | %s",
-            actions_taken,
-            game_state,
-            method,
-            params or "",
-            card_detail,
-            getattr(action, "reason", ""),
-        )
-
-        # Stream log — clean action summaries
-        reason = getattr(action, "reason", "")
-        if method == "play" and card_detail:
-            if reason.startswith("milk:"):
-                _stream_log.info("Milk: %s", reason[5:].strip())
-            else:
-                # Extract score from reason like "Full House for 3232 (eff 3232) >= 300 needed"
-                score_m = re.search(r"for (\d+)", reason)
-                hand_name_str = getattr(action, "hand_name", "") or "?"
-                score_str = f"{int(score_m.group(1)):,}" if score_m else "?"
-                chips_remaining = state.get("round", {}).get("chips", 0)
-                blind_need = current_blind_target if isinstance(current_blind_target, int) else 0
-                remaining = blind_need - chips_remaining if blind_need else 0
-                _stream_log.info(
-                    "Play %s → %s / %s needed",
-                    hand_name_str, score_str,
-                    f"{remaining:,}" if remaining > 0 else "0",
-                )
-        elif method == "discard" and card_detail:
-            # Extract chase info from reason like "chase Three of a Kind (26% to hit)..."
-            chase_m = re.search(r"chase (\w[\w ]*?) \((\d+)%", reason) if reason else None
-            if chase_m:
-                _stream_log.info(
-                    "Discard — chasing %s (%s%%)",
-                    chase_m.group(1), chase_m.group(2),
-                )
-            else:
-                _stream_log.info("Discard")
-        elif method == "buy":
-            # Extract buy info from reason
-            _stream_log.info("Bought: %s", reason.split("(")[0].strip() if reason else "?")
-        elif method == "next_round":
-            _stream_log.info("")
+        card_detail = _format_card_detail(method, params, state)
+        _log_action(gs, game_state, method, params, action, card_detail, state)
 
         # Stream mode: highlight cards one at a time before playing/discarding
         if stream_delay > 0 and method in ("play", "discard") and params and "cards" in params:
@@ -844,45 +1028,7 @@ def run_bot(
         if method == "play":
             pre_play_chips = state.get("round", {}).get("chips", 0)
             _scoring_log.info("  PRE_PLAY chips_in_round=%d", pre_play_chips)
-            hand_cards_snap = state.get("hand", {}).get("cards", [])
-            play_indices = set(params.get("cards", []))
-            # Detect The Flint and halve hand levels for accurate scoring
-            # Skip halving if Luchador was sold to disable the boss effect
-            snap_hand_levels = state.get("hands", {})
-            if not state.get("_boss_disabled", False):
-                for b in state.get("blinds", {}).values():
-                    if isinstance(b, dict) and b.get("status") == "CURRENT" and b.get("name") == "The Flint":
-                        from balatro_bot.domain.scoring.base import flint_halve_hand_levels
-                        snap_hand_levels = flint_halve_hand_levels(snap_hand_levels)
-                        break
-
-            # Detect current blind name for snapshot
-            snap_blind_name = ""
-            for b in state.get("blinds", {}).values():
-                if isinstance(b, dict) and b.get("status") == "CURRENT":
-                    snap_blind_name = b.get("name", "")
-                    break
-
-            play_snapshot = {
-                "played": [hand_cards_snap[i] for i in sorted(params.get("cards", [])) if i < len(hand_cards_snap)],
-                "held": [c for j, c in enumerate(hand_cards_snap) if j not in play_indices],
-                "jokers": state.get("jokers", {}).get("cards", []),
-                "hand_levels": snap_hand_levels,
-                "money": state.get("money", 0),
-                "discards_left": state.get("round", {}).get("discards_left", 0),
-                # Game does NOT decrement hands_left before scoring — Acrobat/Dusk
-                # check the pre-play value. Use the raw state value.
-                "hands_left": state.get("round", {}).get("hands_left", 1),
-                "joker_limit": state.get("jokers", {}).get("limit", 5),
-                "hand_name": getattr(action, "hand_name", ""),
-                "ancient_suit": state.get("round", {}).get("ancient_suit"),
-                "deck_count": state.get("cards", {}).get("count", 0),
-                "deck_cards": state.get("cards", {}).get("cards", []),
-                "blind_name": snap_blind_name,
-                "ante": state.get("ante_num", 1),
-                "_boss_disabled": state.get("_boss_disabled", False),
-                "_ox_most_played": state.get("round", {}).get("most_played_poker_hand"),
-            }
+            play_snapshot = _build_play_snapshot(state, params, action)
 
         # Capture expected hand score for chip accounting on timeout
         expected_hand_score = 0
@@ -905,9 +1051,9 @@ def run_bot(
             # (set when Luchador is sold) would otherwise be lost.
             if _boss_disabled_before:
                 state["_boss_disabled"] = True
-            actions_taken += 1
+            gs.actions_taken += 1
             if method == "play":
-                total_hands_played += 1
+                gs.total_hands_played += 1
                 post_chips = state.get("round", {}).get("chips", 0)
                 _scoring_log.info("  POST_PLAY chips_in_round=%d, delta=%d", post_chips, post_chips - pre_play_chips)
                 # The Hook discards 2 held cards BEFORE scoring (before
@@ -916,29 +1062,17 @@ def run_bot(
                 # are applied in joker_effects/complex.py.
                 _log_played_hand(play_snapshot, pre_play_chips, state, fmt_card)
             elif method == "discard":
-                total_discards_used += 1
+                gs.total_discards_used += 1
 
-            # Detect joker roster changes and log strategy shift
-            cur_joker_keys = {j.get("key") for j in state.get("jokers", {}).get("cards", [])}
-            if cur_joker_keys != prev_joker_keys and prev_joker_keys:
-                from balatro_bot.strategy import compute_strategy as _cs
-                new_strat = _cs(state.get("jokers", {}).get("cards", []), state.get("hands", {}))
-                log.info("[STRAT] %s", new_strat.describes())
-                # Luchador sold during a boss blind → boss effect disabled
-                if "j_luchador" in prev_joker_keys and "j_luchador" not in cur_joker_keys:
-                    from balatro_bot.domain.policy.playing import BOSS_BLINDS
-                    if current_blind_name in BOSS_BLINDS:
-                        state["_boss_disabled"] = True
-                        log.info("[BOSS] Luchador sold — %s effect disabled", current_blind_name)
-            prev_joker_keys = cur_joker_keys
+            _detect_joker_changes(gs, state)
 
-            consecutive_errors = 0
+            gs.consecutive_errors = 0
 
             if stream_delay > 0:
                 time.sleep(stream_delay)
         except httpx.TimeoutException:
             if method == "play":
-                total_hands_played += 1  # hand was played, game processed it
+                gs.total_hands_played += 1  # hand was played, game processed it
             log.warning("Timeout on %s(%s) — re-polling gamestate", method, params)
             try:
                 state = client.call("gamestate")
@@ -949,35 +1083,14 @@ def run_bot(
                     break
                 # Victory detection: if ante advanced to 9+ during a play
                 # timeout, the win screen caused the hang — handle it here
-                post_ante = state.get("ante_num", 0)
-                if post_ante >= 9 and not actually_won:
-                    actually_won = True
-                    if current_blind_name:
-                        target = current_blind_target if isinstance(current_blind_target, int) else 0
-                        final_chips = pre_play_chips + expected_hand_score
-                        max_chips_this_blind = max(max_chips_this_blind, final_chips)
-                        log.info(
-                            "VICTORY at ante %s round %s (seed=%s) — scored %s / needed %s — WON | %d hands, %d discards",
-                            post_ante, state.get("round_num", "?"),
-                            state.get("seed", "?"),
-                            f"{final_chips:,}", f"{target:,}",
-                            total_hands_played - hands_at_blind_start,
-                            total_discards_used - discards_at_blind_start,
-                        )
-                        current_blind_name = None
-                    else:
-                        log.info(
-                            "VICTORY at ante %s round %s (seed=%s)",
-                            post_ante, state.get("round_num", "?"),
-                            state.get("seed", "?"),
-                        )
+                _check_victory(gs, state, pre_play_chips, expected_hand_score)
                 # Diagnostic dump on timeout
-                gs = state.get("state", "?")
+                post_state = state.get("state", "?")
                 pack_cards = state.get("pack", {}).get("cards", [])
                 pack_labels = [c.get("label", "?") for c in pack_cards]
                 log.warning(
                     "  post-timeout state=%s pack=%s money=%s ante=%s round=%s",
-                    gs, pack_labels or "none", state.get("money"),
+                    post_state, pack_labels or "none", state.get("money"),
                     state.get("ante_num"), state.get("round_num"),
                 )
                 if pack_cards:
@@ -991,8 +1104,8 @@ def run_bot(
                 log.error("Double timeout — server unresponsive, aborting")
                 raise
         except APIError as e:
-            consecutive_errors += 1
-            log.warning("API error: %s (%s) — retry %d", e.message, e.name, consecutive_errors)
+            gs.consecutive_errors += 1
+            log.warning("API error: %s (%s) — retry %d", e.message, e.name, gs.consecutive_errors)
 
             # If a consumable use was rejected, clear Fool tracking so
             # the rule engine doesn't keep trying the same consumable.
@@ -1002,7 +1115,7 @@ def run_bot(
                         rule._last_used_consumable = None
                         break
 
-            if consecutive_errors >= 5:
+            if gs.consecutive_errors >= 5:
                 log.error("Too many consecutive errors, forcing skip")
                 if game_state in ("TAROT_PACK", "PLANET_PACK", "SPECTRAL_PACK",
                                   "STANDARD_PACK", "BUFFOON_PACK", "SMODS_BOOSTER_OPENED"):
@@ -1013,7 +1126,7 @@ def run_bot(
                 state = client.call("gamestate")
                 if _boss_disabled_before:
                     state["_boss_disabled"] = True
-                consecutive_errors = 0
+                gs.consecutive_errors = 0
             else:
                 time.sleep(poll_interval)
                 state = client.call("gamestate")
@@ -1023,54 +1136,5 @@ def run_bot(
             if saved_timeout is not None:
                 client.timeout = saved_timeout
 
-    # Capture chips from the final state — the loop exits before the top-of-loop
-    # chips tracking can run, so the last play/discard response's chips are missed.
-    final_chips = state.get("round", {}).get("chips", 0)
-    if final_chips > max_chips_this_blind:
-        max_chips_this_blind = final_chips
-
-    # Log final round summary if died on a blind
-    if current_blind_name:
-        log.info(
-            "[ROUND] %s: scored %s / needed %s — LOST | %d hands, %d discards",
-            current_blind_name, f"{max_chips_this_blind:,}",
-            f"{current_blind_target:,}" if isinstance(current_blind_target, int) else current_blind_target,
-            total_hands_played - hands_at_blind_start,
-            total_discards_used - discards_at_blind_start,
-        )
-
-    ante = state.get("ante_num", "?")
-    round_num = state.get("round_num", "?")
-    seed = state.get("seed", "?")
-    if actually_won:
-        log.info(
-            "Game over: VICTORY (died in endless) | seed=%s ante=%s round=%s | %d actions taken",
-            seed, ante, round_num, actions_taken,
-        )
-    elif state.get("won", False):
-        log.info(
-            "Game over: DEFEAT (state.won=true but never reached ante 9) | seed=%s ante=%s round=%s | %d actions taken",
-            seed, ante, round_num, actions_taken,
-        )
-    else:
-        log.info(
-            "Game over: DEFEAT | seed=%s ante=%s round=%s | %d actions taken",
-            seed, ante, round_num, actions_taken,
-        )
-        _stream_log.info("")
-        _stream_log.info("GAME OVER at Ante %s", ante)
-    joker_names = [j.get("label", "?") for j in state.get("jokers", {}).get("cards", [])]
-    log.info(
-        "Summary: $%d | jokers: [%s] | hands=%d discards=%d",
-        state.get("money", 0),
-        ", ".join(joker_names) if joker_names else "none",
-        total_hands_played, total_discards_used,
-    )
-
-    if _win_handler:
-        if actually_won:
-            _win_handler.flush_win(seed)
-        else:
-            _win_handler.reset()
-
-    return actually_won
+    _log_game_over(gs, state)
+    return gs.actually_won

--- a/src/balatro_bot/bot_format.py
+++ b/src/balatro_bot/bot_format.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 
+from balatro_bot.domain.models.card import Card
+
 # Card formatting constants
 SUIT_SYM = {"H": "\u2665", "D": "\u2666", "C": "\u2663", "S": "\u2660"}
 RANK_SYM = {
@@ -13,8 +15,10 @@ RANK_SYM = {
 }
 
 
-def fmt_card(c: dict) -> str:
-    """Format a card dict as a compact label like '10\u2665' or 'A\u2660'."""
+def fmt_card(c: Card | dict) -> str:
+    """Format a card as a compact label like '10\u2665' or 'A\u2660'."""
+    if isinstance(c, Card):
+        return RANK_SYM.get(c.value.rank or "", "?") + SUIT_SYM.get(c.value.suit or "", "?")
     val = c.get("value", {})
     return RANK_SYM.get(val.get("rank", ""), "?") + SUIT_SYM.get(val.get("suit", ""), "?")
 
@@ -56,18 +60,29 @@ def format_deck_snapshot(deck_cards: list) -> str:
     stone_count = 0
 
     for card in deck_cards:
-        mod = card.get("modifier", {})
-        if not isinstance(mod, dict):
-            mod = {}
-        enh = mod.get("enhancement", "")
-        if enh == "STONE":
-            stone_count += 1
-            continue
-        rank = card.get("value", {}).get("rank")
-        suit = card.get("value", {}).get("suit")
-        if not rank or not suit:
-            continue
-        seal = mod.get("seal", "")
+        if isinstance(card, Card):
+            enh = card.modifier.enhancement or ""
+            if enh == "STONE":
+                stone_count += 1
+                continue
+            rank = card.value.rank
+            suit = card.value.suit
+            if not rank or not suit:
+                continue
+            seal = card.modifier.seal or ""
+        else:
+            mod = card.get("modifier", {})
+            if not isinstance(mod, dict):
+                mod = {}
+            enh = mod.get("enhancement", "")
+            if enh == "STONE":
+                stone_count += 1
+                continue
+            rank = card.get("value", {}).get("rank")
+            suit = card.get("value", {}).get("suit")
+            if not rank or not suit:
+                continue
+            seal = mod.get("seal", "")
         by_rank[rank].append((suit, enh, seal))
 
     parts = []

--- a/src/balatro_bot/bot_format.py
+++ b/src/balatro_bot/bot_format.py
@@ -1,0 +1,88 @@
+"""Card and deck formatting utilities for the game loop."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+# Card formatting constants
+SUIT_SYM = {"H": "\u2665", "D": "\u2666", "C": "\u2663", "S": "\u2660"}
+RANK_SYM = {
+    "2": "2", "3": "3", "4": "4", "5": "5", "6": "6",
+    "7": "7", "8": "8", "9": "9", "T": "10",
+    "J": "J", "Q": "Q", "K": "K", "A": "A",
+}
+
+
+def fmt_card(c: dict) -> str:
+    """Format a card dict as a compact label like '10\u2665' or 'A\u2660'."""
+    val = c.get("value", {})
+    return RANK_SYM.get(val.get("rank", ""), "?") + SUIT_SYM.get(val.get("suit", ""), "?")
+
+
+def format_card_detail(method: str, params: dict | None, state: dict) -> str:
+    """Build card detail string for action logging."""
+    if method in ("play", "discard") and "cards" in (params or {}):
+        hand_cards = state.get("hand", {}).get("cards", [])
+        indices = params["cards"]
+        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+        return f" [{', '.join(labels)}]"
+    if method == "use" and params and "cards" in params:
+        hand_cards = state.get("hand", {}).get("cards", [])
+        indices = params["cards"]
+        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+        return f" targets:[{', '.join(labels)}]"
+    if method == "pack" and params and "targets" in params:
+        hand_cards = state.get("hand", {}).get("cards", [])
+        indices = params["targets"]
+        labels = [fmt_card(hand_cards[i]) for i in indices if i < len(hand_cards)]
+        return f" targets:[{', '.join(labels)}]"
+    return ""
+
+
+def format_deck_snapshot(deck_cards: list) -> str:
+    """Format a compact deck snapshot for logging at ante transitions."""
+    ENHANCEMENT_ABBR = {
+        "GLASS": "GL", "STEEL": "ST", "WILD": "WL",
+        "BONUS": "BN", "GOLD": "GD", "LUCKY": "LK", "MULT": "MU",
+    }
+    SEAL_ABBR = {
+        "Red Seal": "RS", "Gold Seal": "GS",
+        "Blue Seal": "BS", "Purple Seal": "PS",
+    }
+    SUIT_SYM_DECK = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"}
+    RANK_ORDER = ["A", "K", "Q", "J", "T", "9", "8", "7", "6", "5", "4", "3", "2"]
+
+    by_rank: dict[str, list] = defaultdict(list)
+    stone_count = 0
+
+    for card in deck_cards:
+        mod = card.get("modifier", {})
+        if not isinstance(mod, dict):
+            mod = {}
+        enh = mod.get("enhancement", "")
+        if enh == "STONE":
+            stone_count += 1
+            continue
+        rank = card.get("value", {}).get("rank")
+        suit = card.get("value", {}).get("suit")
+        if not rank or not suit:
+            continue
+        seal = mod.get("seal", "")
+        by_rank[rank].append((suit, enh, seal))
+
+    parts = []
+    for rank in RANK_ORDER:
+        if rank not in by_rank:
+            continue
+        inner = rank
+        for suit, enh, seal in sorted(by_rank[rank], key=lambda x: x[0]):
+            sym = SUIT_SYM_DECK.get(suit, suit)
+            suffix = ENHANCEMENT_ABBR.get(enh, "") + SEAL_ABBR.get(seal, "")
+            inner += sym + suffix
+        parts.append(f"[{inner}]")
+
+    if stone_count:
+        parts.append(f"[STN\u00d7{stone_count}]")
+
+    total = sum(len(v) for v in by_rank.values()) + stone_count
+    return f"({total}): " + " ".join(parts)

--- a/src/balatro_bot/bot_logging.py
+++ b/src/balatro_bot/bot_logging.py
@@ -1,0 +1,650 @@
+"""Game loop logging helpers — scoring diagnostics, state transitions, action summaries."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from balatro_bot.bot_format import fmt_card, format_deck_snapshot
+
+if TYPE_CHECKING:
+    from balatro_bot.bot import GameLoopState
+
+log = logging.getLogger("balatro_bot")
+_stream_log = logging.getLogger("balatro_stream")
+_scoring_log = logging.getLogger("balatro_scoring")
+
+
+# ---------------------------------------------------------------------------
+# Round / blind result
+# ---------------------------------------------------------------------------
+
+def log_blind_result(gs: GameLoopState, result: str = "WON") -> None:
+    """Log round summary for the current blind."""
+    if not gs.current_blind_name:
+        return
+    target_str = (
+        f"{gs.current_blind_target:,}"
+        if isinstance(gs.current_blind_target, int)
+        else gs.current_blind_target
+    )
+    hands_used = gs.total_hands_played - gs.hands_at_blind_start
+    discards_used = gs.total_discards_used - gs.discards_at_blind_start
+    log.info(
+        "[ROUND] %s: scored %s / needed %s — %s | %d hands, %d discards",
+        gs.current_blind_name, f"{gs.max_chips_this_blind:,}",
+        target_str, result, hands_used, discards_used,
+    )
+    if result == "WON":
+        _stream_log.info(
+            "%s WON — %s / %s | %d hands, %d discards",
+            gs.current_blind_name, f"{gs.max_chips_this_blind:,}",
+            target_str, hands_used, discards_used,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-state logging helpers
+# ---------------------------------------------------------------------------
+
+def log_ante_transition(gs: GameLoopState, state: dict) -> None:
+    """Log roster, strategy, hand levels when ante changes."""
+    ante_num = state.get("ante_num")
+    if ante_num is None or ante_num == gs.last_ante:
+        return
+
+    joker_cards = state.get("jokers", {}).get("cards", [])
+    hand_levels = state.get("hands", {})
+    money = state.get("money", 0)
+
+    # Roster with effect values
+    from balatro_bot.joker_effects import parse_effect_value
+    roster_parts = []
+    for j in joker_cards:
+        label = j.get("label", "?")
+        effect_text = j.get("value", {}).get("effect", "")
+        parsed = parse_effect_value(effect_text) if effect_text else {}
+        if parsed.get("xmult"):
+            roster_parts.append(f"{label}(X{parsed['xmult']:.1f})")
+        elif parsed.get("mult"):
+            roster_parts.append(f"{label}(+{parsed['mult']:.0f}mult)")
+        elif parsed.get("chips"):
+            roster_parts.append(f"{label}(+{parsed['chips']:.0f}chips)")
+        else:
+            roster_parts.append(label)
+
+    log.info(
+        "[ANTE %s] Roster (%d jokers): [%s]",
+        ante_num, len(joker_cards),
+        ", ".join(roster_parts) if roster_parts else "none",
+    )
+
+    deck_cards = state.get("cards", {}).get("cards", [])
+    log.info("[ANTE %s] Deck %s", ante_num, format_deck_snapshot(deck_cards))
+
+    from balatro_bot.strategy import compute_strategy
+    strat = compute_strategy(joker_cards, hand_levels)
+    log.info("[ANTE %s] Strategy: %s", ante_num, strat.describes())
+
+    leveled = []
+    for ht, data in hand_levels.items():
+        if isinstance(data, dict) and data.get("level", 1) > 1:
+            leveled.append(f"{ht}(lv{data['level']})")
+    if leveled:
+        log.info("[ANTE %s] Money: $%d | Levels: %s", ante_num, money, ", ".join(leveled))
+    else:
+        log.info("[ANTE %s] Money: $%d", ante_num, money)
+
+    _stream_log.info("")
+    _stream_log.info("=== Ante %s / 8 ===", ante_num)
+    joker_names = [j.get("label", "?") for j in joker_cards]
+    _stream_log.info("Jokers: %s", ", ".join(joker_names) if joker_names else "(none)")
+    _stream_log.info("Money: $%d", money)
+
+    gs.last_ante = ante_num
+
+
+def log_shop_state(gs: GameLoopState, state: dict) -> None:
+    """Log shop inventory when it changes."""
+    shop_cards = state.get("shop", {}).get("cards", [])
+    packs = state.get("packs", {}).get("cards", [])
+    vouchers = state.get("vouchers", {}).get("cards", [])
+    shop_id = tuple(c.get("label", "") for c in shop_cards)
+    if shop_id == gs.last_logged_shop:
+        return
+
+    jokers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                    for c in shop_cards if c.get("set") == "JOKER"]
+    consumables_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                         for c in shop_cards if c.get("set") not in ("JOKER",)]
+    packs_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                   for c in packs]
+    vouchers_avail = [f"{c.get('label','?')}(${c.get('cost',{}).get('buy','?')})"
+                      for c in vouchers]
+    parts = []
+    if jokers_avail:
+        parts.append("jokers: " + ", ".join(jokers_avail))
+    if consumables_avail:
+        parts.append("consumables: " + ", ".join(consumables_avail))
+    if packs_avail:
+        parts.append("packs: " + ", ".join(packs_avail))
+    if vouchers_avail:
+        parts.append("vouchers: " + ", ".join(vouchers_avail))
+    money = state.get("money", 0)
+    log.info("Shop ($%d): %s", money, " | ".join(parts) if parts else "(empty)")
+    gs.last_logged_shop = shop_id
+
+
+def log_blind_transition(gs: GameLoopState, state: dict) -> None:
+    """Detect blind select changes, log previous blind result, set up new blind tracking."""
+    blinds = state.get("blinds", {})
+    blind_id = tuple(
+        (k, b.get("name", ""), b.get("status", ""))
+        for k, b in blinds.items() if isinstance(b, dict)
+    )
+    if blind_id == gs.last_logged_blind:
+        return
+
+    for key, b in blinds.items():
+        if isinstance(b, dict) and b.get("status") in ("SELECT", "CURRENT"):
+            name = b.get("name", "?")
+            score = b.get("score", "?")
+            # Log previous blind summary before overwriting
+            if gs.current_blind_name and gs.max_chips_this_blind > 0:
+                log_blind_result(gs, "WON")
+            log.info("Blind: %s (need %s chips)", name, score)
+            _stream_log.info("")
+            _stream_log.info("--- %s — need %s chips ---", name, f"{score:,}" if isinstance(score, int) else score)
+            gs.current_blind_name = name
+            gs.current_blind_target = score
+            gs.max_chips_this_blind = 0
+            state.pop("_boss_disabled", None)
+            gs.hands_at_blind_start = gs.total_hands_played
+            gs.discards_at_blind_start = gs.total_discards_used
+            gs.hand_context_logged = False
+            break
+    gs.last_logged_blind = blind_id
+
+
+def log_hand_state(gs: GameLoopState, state: dict) -> None:
+    """Log hand composition and first-hand-of-blind context."""
+    hand_cards = state.get("hand", {}).get("cards", [])
+    hand_id = tuple(c.get("label", "") for c in hand_cards)
+    if hand_id == gs.last_logged_hand:
+        return
+
+    hand_str = ", ".join(fmt_card(c) for c in hand_cards)
+    if gs.prev_hand_labels:
+        remaining = list(gs.prev_hand_labels)
+        drew = []
+        for c in hand_cards:
+            lbl = c.get("label", "")
+            if lbl in remaining:
+                remaining.remove(lbl)
+            else:
+                drew.append(fmt_card(c))
+        drew_str = f" | drew: [{', '.join(drew)}]" if drew else ""
+    else:
+        drew_str = ""
+    debuffed = [fmt_card(c) for c in hand_cards
+                if isinstance(c.get("state", {}), dict) and c["state"].get("debuff")]
+    debuff_str = f" | DEBUFFED: [{', '.join(debuffed)}]" if debuffed else ""
+    log.info("Hand: [%s]%s%s", hand_str, drew_str, debuff_str)
+    gs.prev_hand_labels = [c.get("label", "") for c in hand_cards]
+    gs.last_logged_hand = hand_id
+
+    # First hand of a new blind — log context once
+    if not gs.hand_context_logged and gs.current_blind_name:
+        jokers_now = state.get("jokers", {}).get("cards", [])
+        hand_levels_now = state.get("hands", {})
+        rnd = state.get("round", {})
+        from balatro_bot.domain.scoring.search import best_hand as _bh
+        jlimit = state.get("jokers", {}).get("limit", 5)
+        bh = _bh(hand_cards, hand_levels_now, jokers=jokers_now, joker_limit=jlimit)
+        best_score = bh.total if bh else 0
+        best_name = bh.hand_name if bh else "?"
+        blind_need = gs.current_blind_target or 0
+        can_win = best_score >= blind_need if blind_need else False
+        log.info(
+            "[HAND] Best: %s for %s | Blind: %s needs %s | Hands: %d | %s",
+            best_name, f"{best_score:,}", gs.current_blind_name,
+            f"{blind_need:,}" if isinstance(blind_need, int) else blind_need,
+            rnd.get("hands_left", 0),
+            "CAN WIN" if can_win else "NEED MORE",
+        )
+        _stream_log.info(
+            "Best: %s for %s | Hands: %d | %s",
+            best_name, f"{best_score:,}",
+            rnd.get("hands_left", 0),
+            "CAN WIN" if can_win else "NEED MORE",
+        )
+        gs.hand_context_logged = True
+
+
+# ---------------------------------------------------------------------------
+# Action logging
+# ---------------------------------------------------------------------------
+
+def log_action(
+    gs: GameLoopState, game_state: str, method: str, params: dict | None,
+    action: object, card_detail: str, state: dict,
+) -> None:
+    """Log action to both main and stream loggers."""
+    log.info(
+        "[#%d] %s -> %s(%s)%s | %s",
+        gs.actions_taken, game_state, method, params or "",
+        card_detail, getattr(action, "reason", ""),
+    )
+
+    reason = getattr(action, "reason", "")
+    if method == "play" and card_detail:
+        if reason.startswith("milk:"):
+            _stream_log.info("Milk: %s", reason[5:].strip())
+        else:
+            score_m = re.search(r"for (\d+)", reason)
+            hand_name_str = getattr(action, "hand_name", "") or "?"
+            score_str = f"{int(score_m.group(1)):,}" if score_m else "?"
+            chips_remaining = state.get("round", {}).get("chips", 0)
+            blind_need = gs.current_blind_target if isinstance(gs.current_blind_target, int) else 0
+            remaining = blind_need - chips_remaining if blind_need else 0
+            _stream_log.info(
+                "Play %s \u2192 %s / %s needed",
+                hand_name_str, score_str,
+                f"{remaining:,}" if remaining > 0 else "0",
+            )
+    elif method == "discard" and card_detail:
+        chase_m = re.search(r"chase (\w[\w ]*?) \((\d+)%", reason) if reason else None
+        if chase_m:
+            _stream_log.info(
+                "Discard \u2014 chasing %s (%s%%)",
+                chase_m.group(1), chase_m.group(2),
+            )
+        else:
+            _stream_log.info("Discard")
+    elif method == "buy":
+        _stream_log.info("Bought: %s", reason.split("(")[0].strip() if reason else "?")
+    elif method == "next_round":
+        _stream_log.info("")
+
+
+# ---------------------------------------------------------------------------
+# Play snapshot + joker changes + game over
+# ---------------------------------------------------------------------------
+
+def build_play_snapshot(state: dict, params: dict, action: object) -> dict:
+    """Build the pre-play snapshot dict for scoring diagnostics."""
+    from balatro_bot.bot import find_current_blind
+
+    hand_cards_snap = state.get("hand", {}).get("cards", [])
+    play_indices = set(params.get("cards", []))
+
+    # Detect The Flint and halve hand levels for accurate scoring
+    snap_hand_levels = state.get("hands", {})
+    if not state.get("_boss_disabled", False):
+        blind_info = find_current_blind(state)
+        if blind_info and blind_info[0] == "The Flint":
+            from balatro_bot.domain.scoring.base import flint_halve_hand_levels
+            snap_hand_levels = flint_halve_hand_levels(snap_hand_levels)
+
+    blind_info = find_current_blind(state)
+    snap_blind_name = blind_info[0] if blind_info else ""
+
+    return {
+        "played": [hand_cards_snap[i] for i in sorted(params.get("cards", [])) if i < len(hand_cards_snap)],
+        "held": [c for j, c in enumerate(hand_cards_snap) if j not in play_indices],
+        "jokers": state.get("jokers", {}).get("cards", []),
+        "hand_levels": snap_hand_levels,
+        "money": state.get("money", 0),
+        "discards_left": state.get("round", {}).get("discards_left", 0),
+        # Game does NOT decrement hands_left before scoring — Acrobat/Dusk
+        # check the pre-play value. Use the raw state value.
+        "hands_left": state.get("round", {}).get("hands_left", 1),
+        "joker_limit": state.get("jokers", {}).get("limit", 5),
+        "hand_name": getattr(action, "hand_name", ""),
+        "ancient_suit": state.get("round", {}).get("ancient_suit"),
+        "deck_count": state.get("cards", {}).get("count", 0),
+        "deck_cards": state.get("cards", {}).get("cards", []),
+        "blind_name": snap_blind_name,
+        "ante": state.get("ante_num", 1),
+        "_boss_disabled": state.get("_boss_disabled", False),
+        "_ox_most_played": state.get("round", {}).get("most_played_poker_hand"),
+    }
+
+
+def detect_joker_changes(gs: GameLoopState, state: dict) -> None:
+    """Detect joker roster changes, log strategy shift, handle Luchador sell."""
+    cur_joker_keys = {j.get("key") for j in state.get("jokers", {}).get("cards", [])}
+    if cur_joker_keys != gs.prev_joker_keys and gs.prev_joker_keys:
+        from balatro_bot.strategy import compute_strategy as _cs
+        new_strat = _cs(state.get("jokers", {}).get("cards", []), state.get("hands", {}))
+        log.info("[STRAT] %s", new_strat.describes())
+        # Luchador sold during a boss blind → boss effect disabled
+        if "j_luchador" in gs.prev_joker_keys and "j_luchador" not in cur_joker_keys:
+            from balatro_bot.domain.policy.playing import BOSS_BLINDS
+            if gs.current_blind_name in BOSS_BLINDS:
+                state["_boss_disabled"] = True
+                log.info("[BOSS] Luchador sold — %s effect disabled", gs.current_blind_name)
+    gs.prev_joker_keys = cur_joker_keys
+
+
+def log_game_over(gs: GameLoopState, state: dict) -> None:
+    """Log game over summary and handle win capture."""
+    from balatro_bot.bot import _win_handler
+
+    # Capture chips from the final state
+    final_chips = state.get("round", {}).get("chips", 0)
+    if final_chips > gs.max_chips_this_blind:
+        gs.max_chips_this_blind = final_chips
+
+    # Log final round summary if died on a blind
+    log_blind_result(gs, "LOST")
+
+    ante = state.get("ante_num", "?")
+    round_num = state.get("round_num", "?")
+    seed = state.get("seed", "?")
+    if gs.actually_won:
+        log.info(
+            "Game over: VICTORY (died in endless) | seed=%s ante=%s round=%s | %d actions taken",
+            seed, ante, round_num, gs.actions_taken,
+        )
+    elif state.get("won", False):
+        log.info(
+            "Game over: DEFEAT (state.won=true but never reached ante 9) | seed=%s ante=%s round=%s | %d actions taken",
+            seed, ante, round_num, gs.actions_taken,
+        )
+    else:
+        log.info(
+            "Game over: DEFEAT | seed=%s ante=%s round=%s | %d actions taken",
+            seed, ante, round_num, gs.actions_taken,
+        )
+        _stream_log.info("")
+        _stream_log.info("GAME OVER at Ante %s", ante)
+    joker_names = [j.get("label", "?") for j in state.get("jokers", {}).get("cards", [])]
+    log.info(
+        "Summary: $%d | jokers: [%s] | hands=%d discards=%d",
+        state.get("money", 0),
+        ", ".join(joker_names) if joker_names else "none",
+        gs.total_hands_played, gs.total_discards_used,
+    )
+
+    if _win_handler:
+        if gs.actually_won:
+            _win_handler.flush_win(seed)
+        else:
+            _win_handler.reset()
+
+
+# ---------------------------------------------------------------------------
+# Scoring diagnostics (the 270-line _log_played_hand)
+# ---------------------------------------------------------------------------
+
+def log_played_hand(snapshot: dict | None, pre_chips: int, new_state: dict) -> None:
+    """Log a detailed scoring breakdown for a hand that was just played."""
+    if not snapshot or not _scoring_log.handlers:
+        return
+    try:
+        from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
+        from balatro_bot.domain.scoring.estimate import score_hand_detailed
+
+        played = snapshot["played"]
+        hand_name = snapshot["hand_name"]
+        if not hand_name:
+            hand_name = classify_hand(played)
+
+        joker_keys = {j.get("key") for j in snapshot["jokers"]}
+        has_splash = "j_splash" in joker_keys
+        four_fingers = "j_four_fingers" in joker_keys
+        smeared = "j_smeared" in joker_keys
+        shortcut = "j_shortcut" in joker_keys
+        scoring = played if has_splash else _scoring_cards_for(hand_name, played, four_fingers=four_fingers, smeared=smeared, shortcut=shortcut)
+
+        # Apply boss blind level adjustments for scoring estimate
+        # NOTE: The Flint halving is already applied in the snapshot,
+        # so we must NOT halve again here — that caused double-halving.
+        hand_levels = snapshot["hand_levels"]
+        blind_name = snapshot.get("blind_name", "")
+        boss_disabled = snapshot.get("_boss_disabled", False)
+        if blind_name == "The Arm" and not boss_disabled:
+            from balatro_bot.domain.scoring.base import arm_reduce_hand_levels
+            hand_levels = arm_reduce_hand_levels(hand_levels)
+
+        # Boss blind hand-type restrictions — zero estimate when hand is invalid
+        blind_zeroed = False
+        if not boss_disabled:
+            if blind_name == "The Mouth":
+                current_played = False
+                other_played = False
+                for ht, data in hand_levels.items():
+                    if isinstance(data, dict) and data.get("played_this_round", 0) > 0:
+                        if ht == hand_name:
+                            current_played = True
+                        else:
+                            other_played = True
+                if other_played and not current_played:
+                    blind_zeroed = True
+            elif blind_name == "The Eye":
+                for ht, data in hand_levels.items():
+                    if ht == hand_name and isinstance(data, dict) and data.get("played_this_round", 0) > 0:
+                        blind_zeroed = True
+                        break
+            elif blind_name == "The Psychic" and len(played) < 5:
+                blind_zeroed = True
+
+        # The Ox locks most-played hand at blind start
+        _ox_mp = snapshot.get("_ox_most_played")
+
+        detail = score_hand_detailed(
+            hand_name, scoring,
+            hand_levels=hand_levels,
+            jokers=snapshot["jokers"],
+            played_cards=played,
+            held_cards=snapshot["held"],
+            money=snapshot["money"],
+            discards_left=snapshot["discards_left"],
+            hands_left=snapshot["hands_left"],
+            joker_limit=snapshot["joker_limit"],
+            ancient_suit=snapshot.get("ancient_suit"),
+            deck_count=snapshot.get("deck_count", 0),
+            deck_cards=snapshot.get("deck_cards"),
+            blind_name="" if boss_disabled else blind_name,
+            ox_most_played=_ox_mp,
+        )
+
+        if blind_zeroed:
+            detail["total"] = 0
+
+        post_chips = new_state.get("round", {}).get("chips", 0)
+        actual_chips = post_chips - pre_chips
+        actual_reliable = actual_chips > 0
+        cards_str = ", ".join(fmt_card(c) for c in played)
+
+        joker_parts = []
+        for entry in detail["joker_contributions"]:
+            label, dc, dm = entry[0], entry[1], entry[2]
+            xm = entry[3] if len(entry) > 3 else 1.0
+            parts = []
+            if dc:
+                parts.append(f"+{dc:.0f}c")
+            # Show xmult as multiplier if it's clearly multiplicative (ratio > 1.1 or < 0.9)
+            if xm > 1.01 or xm < 0.99:
+                parts.append(f"x{xm:.2f}")
+            elif dm:
+                parts.append(f"+{dm:.1f}m")
+            if parts:
+                joker_parts.append(f"{label}({', '.join(parts)})")
+        joker_str = ", ".join(joker_parts) if joker_parts else "none"
+
+        mismatch = ""
+        is_mismatch = actual_reliable and detail["total"] != actual_chips
+        # Probability-based effects make scoring non-deterministic — the bot
+        # uses expected values but the game rolls dice.  Tag these as noise.
+        if is_mismatch:
+            noise_sources = []
+            if "j_misprint" in joker_keys:
+                noise_sources.append("misprint")
+            if "j_bloodstone" in joker_keys:
+                noise_sources.append("bloodstone")
+            # Space Joker: 1/8 chance to upgrade hand level — unpredictable
+            if "j_space" in joker_keys:
+                noise_sources.append("space")
+            # Lucky cards: 1/5 chance for +20 mult per scored Lucky card
+            if any(
+                isinstance(c.get("modifier", {}), dict)
+                and c.get("modifier", {}).get("enhancement") == "LUCKY"
+                for c in scoring
+            ):
+                noise_sources.append("lucky")
+            # Hook's boss effect (discard 2 cards) fires BEFORE On Played
+            # jokers.  Modelled: Green Joker, Ramen, Yorick.
+            # Castle/Hit the Road gain from Hook's random discards — inherently
+            # noisy since we can't predict which cards Hook picks.
+            if blind_name == "The Hook":
+                hook_noisy = {"j_castle", "j_hit_the_road",
+                              "j_ride_the_bus",
+                              "j_runner", "j_square", "j_trousers", "j_wee",
+                              "j_lucky_cat", "j_obelisk"}
+                for jk in joker_keys & hook_noisy:
+                    noise_sources.append(f"hook+{jk.removeprefix('j_')}")
+                # Hook removes held cards before scoring — held-card effects
+                # (Steel, Baron, Smiley Face, Blackboard) see a reduced hand
+                # that the bot can't predict.
+                held = snapshot.get("held", [])
+                _hmod = lambda c: c.get("modifier", {}) if isinstance(c.get("modifier", {}), dict) else {}
+                if any(_hmod(c).get("enhancement") == "STEEL" for c in held):
+                    noise_sources.append("hook+steel")
+                if "j_baron" in joker_keys and any(c.get("value", {}).get("rank") == "K" for c in held):
+                    noise_sources.append("hook+baron")
+                if "j_smiley" in joker_keys:
+                    noise_sources.append("hook+smiley")
+                if "j_blackboard" in joker_keys:
+                    noise_sources.append("hook+blackboard")
+            if noise_sources:
+                diff = actual_chips - detail["total"]
+                mismatch = f" MISMATCH_NOISE(diff={diff:+d}, {'+'.join(noise_sources)})"
+                is_mismatch = False
+        if is_mismatch:
+            diff = actual_chips - detail["total"]
+            if abs(diff) <= 1:
+                mismatch = f" MISMATCH_NOISE(diff={diff:+d}, rounding)"
+                is_mismatch = False
+            else:
+                mismatch = f" MISMATCH(diff={diff:+d})"
+        if not mismatch and not actual_reliable:
+            mismatch = " (actual unreliable)"
+
+        scoring_str = ", ".join(fmt_card(c) for c in scoring)
+
+        def _mod(c: dict) -> dict:
+            m = c.get("modifier", {})
+            return m if isinstance(m, dict) else {}
+
+        enhs_str = ",".join(sorted(filter(None, {_mod(c).get("enhancement", "") for c in scoring})))
+        seals_str = ",".join(sorted(filter(None, {_mod(c).get("seal", "") for c in scoring})))
+        eds_str = ",".join(sorted(filter(None, {_mod(c).get("edition", "") for c in scoring})))
+
+        _scoring_log.info(
+            "%s [%s] scoring=[%s](%d) | base: %d/%d | pre-joker: %d/%.1f | jokers: [%s] | "
+            "final: %d/%.1f | enhs=[%s] seals=[%s] eds=[%s] | "
+            "blind=%s ante=%d hands_left=%d | est=%d actual=%d%s",
+            detail["hand_name"], cards_str, scoring_str, len(scoring),
+            detail["base_chips"], detail["base_mult"],
+            detail["pre_joker_chips"], detail["pre_joker_mult"],
+            joker_str,
+            detail["post_joker_chips"], detail["post_joker_mult"],
+            enhs_str, seals_str, eds_str,
+            snapshot.get("blind_name", ""), snapshot.get("ante", 0), snapshot.get("hands_left", 0),
+            detail["total"], actual_chips,
+            mismatch,
+        )
+
+        # On mismatch, dump per-card scoring breakdown and raw card data
+        if is_mismatch:
+            from balatro_bot.cards import card_chip_value, card_mult_value, card_xmult_value, _modifier
+            from balatro_bot.joker_effects import parse_effect_value, retrigger_count, ScoreContext
+
+            # Dump raw hand level data from API for this hand type
+            hand_level_data = snapshot["hand_levels"].get(hand_name, {})
+            _scoring_log.info("  hand_level[%s] = %s", hand_name, hand_level_data)
+
+            # Score context intermediate states
+            _scoring_log.info(
+                "  scoring_ctx: base=%d/%d pre_joker=%d/%.1f post_joker=%d/%.1f total=%d",
+                detail["base_chips"], detail["base_mult"],
+                detail["pre_joker_chips"], detail["pre_joker_mult"],
+                detail["post_joker_chips"], detail["post_joker_mult"],
+                detail["total"],
+            )
+
+            # Build minimal context for retrigger calculation
+            ctx_for_retrigger = ScoreContext(
+                chips=0, mult=0.0, hand_name=hand_name,
+                scoring_cards=scoring, played_cards=played,
+                held_cards=snapshot["held"], hand_levels=snapshot["hand_levels"],
+                jokers=snapshot["jokers"], money=0, discards_left=0, hands_left=1,
+                joker_limit=snapshot.get("joker_limit", 5),
+                pareidolia="j_pareidolia" in joker_keys,
+                smeared="j_smeared" in joker_keys,
+            )
+
+            for i, c in enumerate(scoring):
+                mod = _modifier(c)
+                rank = c.get("value", {}).get("rank", "?")
+                suit = c.get("value", {}).get("suit", "?")
+                enh = mod.get("enhancement", "")
+                edition = mod.get("edition", "")
+                seal = mod.get("seal", "")
+                debuff = c.get("state", {})
+                if isinstance(debuff, dict):
+                    debuff = debuff.get("debuff", False)
+                else:
+                    debuff = False
+                chips = card_chip_value(c)
+                mult = card_mult_value(c)
+                xmult = card_xmult_value(c)
+                perma = c.get("value", {}).get("perma_bonus", 0) or 0
+                triggers = retrigger_count(c, ctx_for_retrigger)
+                _scoring_log.info(
+                    "  card[%d] %s %s (SCORING) | chips=%d mult=%.1f xmult=%.2f triggers=%d | "
+                    "enh=%s ed=%s seal=%s debuff=%s perma=%d | raw_mod=%s",
+                    i, rank, suit,
+                    chips, mult, xmult, triggers,
+                    enh or "-", edition or "-", seal or "-", debuff, perma,
+                    mod,
+                )
+            # Dump all held cards (Baron checks Kings, Shoot the Moon checks Queens, etc.)
+            for i, c in enumerate(snapshot["held"]):
+                mod_h = _modifier(c)
+                rank_h = c.get("value", {}).get("rank", "?")
+                suit_h = c.get("value", {}).get("suit", "?")
+                enh_h = mod_h.get("enhancement", "")
+                _scoring_log.info("  held[%d] %s %s | enh=%s", i, rank_h, suit_h, enh_h or "-")
+            # Dump raw joker ability data + parsed values so we can compare
+            for i, j in enumerate(snapshot["jokers"]):
+                ability = j.get("value", {}).get("ability", {})
+                effect = j.get("value", {}).get("effect", "") or ""
+                if not isinstance(effect, str):
+                    effect = ""
+                parsed = parse_effect_value(effect)
+                rarity = j.get("value", {}).get("rarity", "?")
+                jmod = j.get("modifier", {})
+                if not isinstance(jmod, dict):
+                    jmod = {}
+                jed = jmod.get("edition", "")
+                jed_parts = []
+                if jed:
+                    jed_parts.append(jed)
+                    if jmod.get("edition_mult"):
+                        jed_parts.append(f"mult={jmod['edition_mult']}")
+                    if jmod.get("edition_chips"):
+                        jed_parts.append(f"chips={jmod['edition_chips']}")
+                    if jmod.get("edition_x_mult"):
+                        jed_parts.append(f"x_mult={jmod['edition_x_mult']}")
+                jed_str = " ".join(jed_parts) if jed_parts else "-"
+                _scoring_log.info(
+                    "  joker[%d] %s | rarity=%s ed=%s | ability=%s | parsed=%s | effect=%s",
+                    i, j.get("key", "?"), rarity, jed_str, ability, parsed,
+                    effect[:120] if effect else "-",
+                )
+    except Exception as e:
+        _scoring_log.warning("scoring log error: %s", e)

--- a/src/balatro_bot/bot_logging.py
+++ b/src/balatro_bot/bot_logging.py
@@ -7,6 +7,8 @@ import re
 from typing import TYPE_CHECKING
 
 from balatro_bot.bot_format import fmt_card, format_deck_snapshot
+from balatro_bot.cards import joker_key
+from balatro_bot.domain.models.card import Card
 
 if TYPE_CHECKING:
     from balatro_bot.bot import GameLoopState
@@ -188,10 +190,12 @@ def log_hand_state(gs: GameLoopState, state: dict) -> None:
     else:
         drew_str = ""
     debuffed = [fmt_card(c) for c in hand_cards
-                if isinstance(c.get("state", {}), dict) and c["state"].get("debuff")]
+                if (c.state.debuff if isinstance(c, Card)
+                    else (isinstance(c.get("state", {}), dict) and c["state"].get("debuff")))]
     debuff_str = f" | DEBUFFED: [{', '.join(debuffed)}]" if debuffed else ""
     log.info("Hand: [%s]%s%s", hand_str, drew_str, debuff_str)
-    gs.prev_hand_labels = [c.get("label", "") for c in hand_cards]
+    gs.prev_hand_labels = [(c.label if isinstance(c, Card) else c.get("label", ""))
+                           for c in hand_cards]
     gs.last_logged_hand = hand_id
 
     # First hand of a new blind — log context once
@@ -314,7 +318,7 @@ def build_play_snapshot(state: dict, params: dict, action: object) -> dict:
 
 def detect_joker_changes(gs: GameLoopState, state: dict) -> None:
     """Detect joker roster changes, log strategy shift, handle Luchador sell."""
-    cur_joker_keys = {j.get("key") for j in state.get("jokers", {}).get("cards", [])}
+    cur_joker_keys = {joker_key(j) for j in state.get("jokers", {}).get("cards", [])}
     if cur_joker_keys != gs.prev_joker_keys and gs.prev_joker_keys:
         from balatro_bot.strategy import compute_strategy as _cs
         new_strat = _cs(state.get("jokers", {}).get("cards", []), state.get("hands", {}))
@@ -392,7 +396,7 @@ def log_played_hand(snapshot: dict | None, pre_chips: int, new_state: dict) -> N
         if not hand_name:
             hand_name = classify_hand(played)
 
-        joker_keys = {j.get("key") for j in snapshot["jokers"]}
+        joker_keys = {joker_key(j) for j in snapshot["jokers"]}
         has_splash = "j_splash" in joker_keys
         four_fingers = "j_four_fingers" in joker_keys
         smeared = "j_smeared" in joker_keys
@@ -589,20 +593,29 @@ def log_played_hand(snapshot: dict | None, pre_chips: int, new_state: dict) -> N
 
             for i, c in enumerate(scoring):
                 mod = _modifier(c)
-                rank = c.get("value", {}).get("rank", "?")
-                suit = c.get("value", {}).get("suit", "?")
-                enh = mod.get("enhancement", "")
-                edition = mod.get("edition", "")
-                seal = mod.get("seal", "")
-                debuff = c.get("state", {})
-                if isinstance(debuff, dict):
-                    debuff = debuff.get("debuff", False)
+                if isinstance(c, Card):
+                    rank = c.value.rank or "?"
+                    suit = c.value.suit or "?"
+                    enh = c.modifier.enhancement or ""
+                    edition = c.modifier.edition or ""
+                    seal = c.modifier.seal or ""
+                    debuff = c.state.debuff
+                    perma = c.value.perma_bonus
                 else:
-                    debuff = False
+                    rank = c.get("value", {}).get("rank", "?")
+                    suit = c.get("value", {}).get("suit", "?")
+                    enh = mod.get("enhancement", "")
+                    edition = mod.get("edition", "")
+                    seal = mod.get("seal", "")
+                    debuff = c.get("state", {})
+                    if isinstance(debuff, dict):
+                        debuff = debuff.get("debuff", False)
+                    else:
+                        debuff = False
+                    perma = c.get("value", {}).get("perma_bonus", 0) or 0
                 chips = card_chip_value(c)
                 mult = card_mult_value(c)
                 xmult = card_xmult_value(c)
-                perma = c.get("value", {}).get("perma_bonus", 0) or 0
                 triggers = retrigger_count(c, ctx_for_retrigger)
                 _scoring_log.info(
                     "  card[%d] %s %s (SCORING) | chips=%d mult=%.1f xmult=%.2f triggers=%d | "
@@ -614,10 +627,15 @@ def log_played_hand(snapshot: dict | None, pre_chips: int, new_state: dict) -> N
                 )
             # Dump all held cards (Baron checks Kings, Shoot the Moon checks Queens, etc.)
             for i, c in enumerate(snapshot["held"]):
-                mod_h = _modifier(c)
-                rank_h = c.get("value", {}).get("rank", "?")
-                suit_h = c.get("value", {}).get("suit", "?")
-                enh_h = mod_h.get("enhancement", "")
+                if isinstance(c, Card):
+                    rank_h = c.value.rank or "?"
+                    suit_h = c.value.suit or "?"
+                    enh_h = c.modifier.enhancement or ""
+                else:
+                    mod_h = _modifier(c)
+                    rank_h = c.get("value", {}).get("rank", "?")
+                    suit_h = c.get("value", {}).get("suit", "?")
+                    enh_h = mod_h.get("enhancement", "")
                 _scoring_log.info("  held[%d] %s %s | enh=%s", i, rank_h, suit_h, enh_h or "-")
             # Dump raw joker ability data + parsed values so we can compare
             for i, j in enumerate(snapshot["jokers"]):
@@ -643,7 +661,7 @@ def log_played_hand(snapshot: dict | None, pre_chips: int, new_state: dict) -> N
                 jed_str = " ".join(jed_parts) if jed_parts else "-"
                 _scoring_log.info(
                     "  joker[%d] %s | rarity=%s ed=%s | ability=%s | parsed=%s | effect=%s",
-                    i, j.get("key", "?"), rarity, jed_str, ability, parsed,
+                    i, joker_key(j) or "?", rarity, jed_str, ability, parsed,
                     effect[:120] if effect else "-",
                 )
     except Exception as e:

--- a/src/balatro_bot/bot_logging.py
+++ b/src/balatro_bot/bot_logging.py
@@ -91,7 +91,7 @@ def log_ante_transition(gs: GameLoopState, state: dict) -> None:
 
     leveled = []
     for ht, data in hand_levels.items():
-        if isinstance(data, dict) and data.get("level", 1) > 1:
+        if hasattr(data, "get") and data.get("level", 1) > 1:
             leveled.append(f"{ht}(lv{data['level']})")
     if leveled:
         log.info("[ANTE %s] Money: $%d | Levels: %s", ante_num, money, ", ".join(leveled))
@@ -190,12 +190,10 @@ def log_hand_state(gs: GameLoopState, state: dict) -> None:
     else:
         drew_str = ""
     debuffed = [fmt_card(c) for c in hand_cards
-                if (c.state.debuff if isinstance(c, Card)
-                    else (isinstance(c.get("state", {}), dict) and c["state"].get("debuff")))]
+                if isinstance(c.get("state", {}), dict) and c["state"].get("debuff")]
     debuff_str = f" | DEBUFFED: [{', '.join(debuffed)}]" if debuffed else ""
     log.info("Hand: [%s]%s%s", hand_str, drew_str, debuff_str)
-    gs.prev_hand_labels = [(c.label if isinstance(c, Card) else c.get("label", ""))
-                           for c in hand_cards]
+    gs.prev_hand_labels = [c.get("label", "") for c in hand_cards]
     gs.last_logged_hand = hand_id
 
     # First hand of a new blind — log context once

--- a/src/balatro_bot/cards.py
+++ b/src/balatro_bot/cards.py
@@ -2,6 +2,8 @@
 
 Both hand_evaluator and joker_effects import from here, breaking the
 dependency cycle between them.
+
+Accepts both typed Card objects and raw dicts during the migration period.
 """
 
 from __future__ import annotations
@@ -9,75 +11,144 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from balatro_bot.constants import ALL_SUITS, RANK_CHIPS, RANK_ORDER
+from balatro_bot.domain.models.card import Card
+from balatro_bot.domain.models.joker import Joker
 
 if TYPE_CHECKING:
     from typing import Any
 
+    CardLike = Card | dict[str, Any]
+    JokerLike = Joker | dict[str, Any]
 
-def _modifier(card: dict[str, Any]) -> dict[str, Any]:
-    """Return the modifier dict, handling the API returning [] for empty."""
+
+def _modifier(card: CardLike) -> dict[str, Any]:
+    """Return the modifier as a dict, handling both Card objects and raw dicts.
+
+    For Card objects, converts CardModifier to a dict for backward compat
+    with callers that use .get() on the result.
+    """
+    if isinstance(card, Card):
+        mod = card.modifier
+        d: dict[str, Any] = {}
+        if mod.enhancement is not None:
+            d["enhancement"] = mod.enhancement
+        if mod.edition is not None:
+            d["edition"] = mod.edition
+        if mod.seal is not None:
+            d["seal"] = mod.seal
+        if mod.edition_chips:
+            d["edition_chips"] = mod.edition_chips
+        if mod.edition_mult:
+            d["edition_mult"] = mod.edition_mult
+        if mod.edition_x_mult:
+            d["edition_x_mult"] = mod.edition_x_mult
+        if mod.enhancement_x_mult:
+            d["enhancement_x_mult"] = mod.enhancement_x_mult
+        return d
     m = card.get("modifier", {})
     return m if isinstance(m, dict) else {}
 
 
-def _state(card: dict[str, Any]) -> dict[str, Any]:
-    """Return the state dict, handling the API returning [] for empty."""
+def _state(card: CardLike) -> dict[str, Any]:
+    """Return the state as a dict, handling both Card objects and raw dicts."""
+    if isinstance(card, Card):
+        return {"debuff": card.state.debuff} if card.state.debuff else {}
     s = card.get("state", {})
     return s if isinstance(s, dict) else {}
 
 
-def is_debuffed(card: dict[str, Any]) -> bool:
+def is_debuffed(card: CardLike) -> bool:
+    if isinstance(card, Card):
+        return card.state.debuff
     return _state(card).get("debuff", False) is True
 
 
-def is_joker_debuffed(joker: dict[str, Any]) -> bool:
+def is_joker_debuffed(joker: JokerLike) -> bool:
     """True if a joker is debuffed (e.g. by Crimson Heart).
 
     The API signals this via the effect text becoming
     ``"All abilities are disabled"`` and/or a state.debuff flag.
     """
+    if isinstance(joker, Joker):
+        if joker.state.debuff:
+            return True
+        return joker.value.effect == "All abilities are disabled"
     if _state(joker).get("debuff", False) is True:
         return True
     effect = joker.get("value", {}).get("effect", "")
     return isinstance(effect, str) and effect == "All abilities are disabled"
 
 
-def card_rank(card: dict[str, Any]) -> str | None:
+def joker_key(joker: JokerLike) -> str:
+    """Return a joker's key, handling both Joker objects and raw dicts."""
+    if isinstance(joker, Joker):
+        return joker.key
+    return joker.get("key", "")
+
+
+def card_rank(card: CardLike) -> str | None:
     """Return the rank character, or None for Stone/non-playing cards."""
+    if isinstance(card, Card):
+        if card.modifier.enhancement == "STONE":
+            return None
+        return card.value.rank
     if _modifier(card).get("enhancement") == "STONE":
         return None
     return card.get("value", {}).get("rank")
 
 
-def card_suit(card: dict[str, Any]) -> str | None:
+def card_suit(card: CardLike) -> str | None:
     """Return the suit character, or None for Stone/non-playing cards."""
+    if isinstance(card, Card):
+        return card.value.suit
     return card.get("value", {}).get("suit")
 
 
-def card_suits(card: dict[str, Any], smeared: bool = False) -> set[str]:
+def card_suits(card: CardLike, smeared: bool = False) -> set[str]:
     """Return all suits this card counts as (Wild = all four, Smeared = merged pairs)."""
-    enhancement = _modifier(card).get("enhancement")
-    if enhancement == "WILD" and not is_debuffed(card):
-        return set(ALL_SUITS)
-    if enhancement == "STONE":
-        return set()  # Stone cards have no suit
-    suit = card_suit(card)
+    if isinstance(card, Card):
+        enhancement = card.modifier.enhancement
+        if enhancement == "WILD" and not card.state.debuff:
+            return set(ALL_SUITS)
+        if enhancement == "STONE":
+            return set()
+        suit = card.value.suit
+    else:
+        enhancement = _modifier(card).get("enhancement")
+        if enhancement == "WILD" and not is_debuffed(card):
+            return set(ALL_SUITS)
+        if enhancement == "STONE":
+            return set()
+        suit = card_suit(card)
     if not suit:
         return set()
     if smeared:
-        # Hearts and Diamonds merge; Clubs and Spades merge
         if suit in ("H", "D"):
             return {"H", "D"}
         return {"C", "S"}
     return {suit}
 
 
-def is_stone(card: dict[str, Any]) -> bool:
+def is_stone(card: CardLike) -> bool:
+    if isinstance(card, Card):
+        return card.modifier.enhancement == "STONE"
     return _modifier(card).get("enhancement") == "STONE"
 
 
-def card_chip_value(card: dict[str, Any]) -> int:
+def card_chip_value(card: CardLike) -> int:
     """Chips this card contributes when it scores in a played hand."""
+    if isinstance(card, Card):
+        if card.state.debuff:
+            return 0
+        mod = card.modifier
+        if mod.enhancement == "STONE":
+            return 50 + card.value.perma_bonus
+        bonus = 30 if mod.enhancement == "BONUS" else 0
+        edition_chips = 50 if mod.edition == "FOIL" else (mod.edition_chips or 0)
+        rank = card.value.rank if mod.enhancement != "STONE" else None
+        base = RANK_CHIPS.get(rank, 0) if rank else 0
+        return base + bonus + edition_chips + card.value.perma_bonus
+    # dict fallback
     if is_debuffed(card):
         return 0
     if is_stone(card):
@@ -86,7 +157,6 @@ def card_chip_value(card: dict[str, Any]) -> int:
     mod = _modifier(card)
     enhancement = mod.get("enhancement", "")
     bonus = 30 if enhancement == "BONUS" else 0
-    # Edition chips: use hardcoded value for known editions (API fields are unreliable)
     edition = mod.get("edition", "")
     edition_chips = 50 if edition == "FOIL" else (mod.get("edition_chips") or 0)
     rank = card_rank(card)
@@ -95,12 +165,23 @@ def card_chip_value(card: dict[str, Any]) -> int:
     return base + bonus + edition_chips + perma
 
 
-def card_mult_value(card: dict[str, Any]) -> float:
+def card_mult_value(card: CardLike) -> float:
     """Enhancement-only additive mult (excludes edition mult).
 
     The game applies edition mult as a separate step AFTER enhancement xmult,
     so it must not be lumped in here.  See card_edition_mult_value().
     """
+    if isinstance(card, Card):
+        if card.state.debuff or card.modifier.enhancement == "STONE":
+            return 0
+        enhancement = card.modifier.enhancement
+        total = 0.0
+        if enhancement == "MULT":
+            total += 4
+        if enhancement == "LUCKY":
+            total += 4
+        return total
+    # dict fallback
     if is_debuffed(card):
         return 0
     if is_stone(card):
@@ -115,12 +196,20 @@ def card_mult_value(card: dict[str, Any]) -> float:
     return total
 
 
-def card_edition_mult_value(card: dict[str, Any]) -> float:
+def card_edition_mult_value(card: CardLike) -> float:
     """Edition additive mult (HOLO = +10).
 
     Applied per card AFTER enhancement xmult in the game's scoring order:
-    playing_card(chips/mult) → enhancement(xmult) → edition(mult) → edition(xmult).
+    playing_card(chips/mult) -> enhancement(xmult) -> edition(mult) -> edition(xmult).
     """
+    if isinstance(card, Card):
+        if card.state.debuff or card.modifier.enhancement == "STONE":
+            return 0
+        mod = card.modifier
+        if mod.edition in ("HOLO", "HOLOGRAPHIC"):
+            return mod.edition_mult or 10
+        return mod.edition_mult or 0
+    # dict fallback
     if is_debuffed(card):
         return 0
     if is_stone(card):
@@ -134,12 +223,19 @@ def card_edition_mult_value(card: dict[str, Any]) -> float:
     return 0
 
 
-def card_xmult_value(card: dict[str, Any]) -> float:
+def card_xmult_value(card: CardLike) -> float:
     """Enhancement-only multiplicative xmult (excludes edition xmult).
 
     Edition xmult (Polychrome) is applied separately after edition mult.
     See card_edition_xmult_value().
     """
+    if isinstance(card, Card):
+        if card.state.debuff or card.modifier.enhancement == "STONE":
+            return 1.0
+        if card.modifier.enhancement == "GLASS":
+            return card.modifier.enhancement_x_mult or 2.0
+        return 1.0
+    # dict fallback
     if is_debuffed(card):
         return 1.0
     if is_stone(card):
@@ -152,11 +248,19 @@ def card_xmult_value(card: dict[str, Any]) -> float:
     return result
 
 
-def card_edition_xmult_value(card: dict[str, Any]) -> float:
+def card_edition_xmult_value(card: CardLike) -> float:
     """Edition multiplicative xmult (Polychrome = x1.5).
 
     Applied per card AFTER edition mult in the game's scoring order.
     """
+    if isinstance(card, Card):
+        if card.state.debuff or card.modifier.enhancement == "STONE":
+            return 1.0
+        mod = card.modifier
+        if mod.edition == "POLYCHROME":
+            return mod.edition_x_mult or 1.5
+        return mod.edition_x_mult or 1.0
+    # dict fallback
     if is_debuffed(card):
         return 1.0
     if is_stone(card):

--- a/src/balatro_bot/cards.py
+++ b/src/balatro_bot/cards.py
@@ -22,12 +22,12 @@ if TYPE_CHECKING:
 
 
 def _modifier(card: CardLike) -> dict[str, Any]:
-    """Return the modifier as a dict, handling both Card objects and raw dicts.
+    """Return the modifier as a dict, handling Card, Joker, and raw dicts.
 
-    For Card objects, converts CardModifier to a dict for backward compat
+    For typed objects, converts CardModifier to a dict for backward compat
     with callers that use .get() on the result.
     """
-    if isinstance(card, Card):
+    if isinstance(card, (Card, Joker)):
         mod = card.modifier
         d: dict[str, Any] = {}
         if mod.enhancement is not None:

--- a/src/balatro_bot/context.py
+++ b/src/balatro_bot/context.py
@@ -33,7 +33,7 @@ class RoundContext:
     hands_left: int
     discards_left: int
     hand_cards: list[dict]
-    hand_levels: dict[str, dict]
+    hand_levels: dict
     jokers: list[dict]
     best: HandCandidate | None
     money: int
@@ -117,7 +117,7 @@ class RoundContext:
         mouth_locked_hand = None
         if blind_name == "The Mouth" and not boss_disabled:
             for hand_name, hand_data in hand_levels.items():
-                if isinstance(hand_data, dict) and hand_data.get("played_this_round", 0) > 0:
+                if hasattr(hand_data, "get") and hand_data.get("played_this_round", 0) > 0:
                     mouth_locked_hand = hand_name
                     break
 
@@ -125,7 +125,7 @@ class RoundContext:
         if blind_name == "The Eye" and not boss_disabled:
             eye_used_hands = {
                 ht for ht, data in hand_levels.items()
-                if isinstance(data, dict) and data.get("played_this_round", 0) > 0
+                if hasattr(data, "get") and data.get("played_this_round", 0) > 0
             }
 
         scoring_suit = None

--- a/src/balatro_bot/domain/models/card.py
+++ b/src/balatro_bot/domain/models/card.py
@@ -1,0 +1,83 @@
+"""Typed playing-card model — replaces raw dict access for cards.
+
+Used by Snapshot for hand_cards, deck_cards, consumables, shop_cards,
+vouchers, and pack_cards.  The factory ``card_from_dict`` handles the
+balatrobot API quirk of returning ``[]`` instead of ``{}`` for empty
+nested objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CardValue:
+    rank: str | None = None
+    suit: str | None = None
+    perma_bonus: int = 0
+
+
+@dataclass(frozen=True)
+class CardModifier:
+    enhancement: str | None = None
+    edition: str | None = None
+    seal: str | None = None
+    edition_chips: int = 0
+    edition_mult: float = 0
+    edition_x_mult: float = 0
+    enhancement_x_mult: float = 0
+
+
+@dataclass(frozen=True)
+class CardState:
+    debuff: bool = False
+
+
+@dataclass(frozen=True)
+class Card:
+    id: int = 0
+    key: str = ""
+    set_: str = ""
+    label: str = ""
+    value: CardValue = field(default_factory=CardValue)
+    modifier: CardModifier = field(default_factory=CardModifier)
+    state: CardState = field(default_factory=CardState)
+    cost: dict = field(default_factory=dict)
+
+
+def _safe_dict(raw) -> dict:
+    """Coerce API value to dict, handling [] for empty."""
+    return raw if isinstance(raw, dict) else {}
+
+
+def card_from_dict(d: dict | Card) -> Card:
+    """Convert a raw API card dict into a typed Card.  Pass-through if already a Card."""
+    if isinstance(d, Card):
+        return d
+    val = _safe_dict(d.get("value", {}))
+    mod = _safe_dict(d.get("modifier", {}))
+    st = _safe_dict(d.get("state", {}))
+
+    return Card(
+        id=d.get("id", 0),
+        key=d.get("key", ""),
+        set_=d.get("set", ""),
+        label=d.get("label", ""),
+        value=CardValue(
+            rank=val.get("rank"),
+            suit=val.get("suit"),
+            perma_bonus=val.get("perma_bonus", 0) or 0,
+        ),
+        modifier=CardModifier(
+            enhancement=mod.get("enhancement"),
+            edition=mod.get("edition"),
+            seal=mod.get("seal"),
+            edition_chips=mod.get("edition_chips", 0) or 0,
+            edition_mult=mod.get("edition_mult", 0) or 0,
+            edition_x_mult=mod.get("edition_x_mult", 0) or 0,
+            enhancement_x_mult=mod.get("enhancement_x_mult", 0) or 0,
+        ),
+        state=CardState(debuff=st.get("debuff", False) is True),
+        cost=d.get("cost") or {},
+    )

--- a/src/balatro_bot/domain/models/hand_level.py
+++ b/src/balatro_bot/domain/models/hand_level.py
@@ -1,0 +1,53 @@
+"""Typed model for hand level data (e.g. Pair lv3: 20 chips, 12 mult)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class HandLevel:
+    """Immutable snapshot of a single hand type's level data."""
+
+    chips: int = 0
+    mult: int = 0
+    level: int = 1
+    played: int = 0
+    played_this_round: int = 0
+
+    def get(self, key: str, default=None):
+        """Dict-compatible .get() for backward compat with callers chaining .get()."""
+        return getattr(self, key, default)
+
+    def __contains__(self, key: str) -> bool:
+        return hasattr(self, key)
+
+    def __getitem__(self, key: str):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+
+def hand_level_from_dict(d: dict | HandLevel) -> HandLevel:
+    """Convert a raw API hand-level dict to a HandLevel object."""
+    if isinstance(d, HandLevel):
+        return d
+    if not isinstance(d, dict):
+        return HandLevel()
+    return HandLevel(
+        chips=d.get("chips", 0),
+        mult=d.get("mult", 0),
+        level=d.get("level", 1),
+        played=d.get("played", 0),
+        played_this_round=d.get("played_this_round", 0),
+    )
+
+
+def hand_levels_from_dict(raw: dict) -> dict[str, HandLevel]:
+    """Convert the full hands dict {hand_name: {chips, mult, ...}} to typed form."""
+    return {
+        name: hand_level_from_dict(data)
+        for name, data in raw.items()
+        if isinstance(data, dict)
+    }

--- a/src/balatro_bot/domain/models/joker.py
+++ b/src/balatro_bot/domain/models/joker.py
@@ -1,0 +1,103 @@
+"""Typed joker model — replaces raw dict access for jokers.
+
+The factory ``joker_from_dict`` handles the balatrobot API quirk of
+returning ``[]`` instead of ``{}`` for empty nested objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from balatro_bot.domain.models.card import CardModifier, CardState, _safe_dict
+
+
+@dataclass(frozen=True)
+class JokerAbility:
+    chips: float | None = None
+    mult: float | None = None
+    t_mult: float | None = None
+    t_chips: float | None = None
+    Xmult: float | None = None
+    x_mult: float | None = None
+    s_mult: float | None = None
+    extra: float | None = None
+    size: int | None = None
+    d_remaining: int | None = None
+    loyalty_remaining: int | None = None
+    min: float | None = None
+    max: float | None = None
+    hand_add: float | None = None
+    chip_mod: float | None = None
+    dollars: float | None = None
+    driver_tally: int | None = None
+    odds: int | None = None
+
+
+@dataclass(frozen=True)
+class JokerValue:
+    effect: str = ""
+    rarity: int | str | None = None
+    ability: JokerAbility = field(default_factory=JokerAbility)
+
+
+@dataclass(frozen=True)
+class Joker:
+    key: str = ""
+    label: str = ""
+    set_: str = ""
+    value: JokerValue = field(default_factory=JokerValue)
+    modifier: CardModifier = field(default_factory=CardModifier)
+    state: CardState = field(default_factory=CardState)
+    cost: dict = field(default_factory=dict)
+
+
+def joker_from_dict(d: dict | Joker) -> Joker:
+    """Convert a raw API joker dict into a typed Joker.  Pass-through if already a Joker."""
+    if isinstance(d, Joker):
+        return d
+
+    val = _safe_dict(d.get("value", {}))
+    mod = _safe_dict(d.get("modifier", {}))
+    st = _safe_dict(d.get("state", {}))
+    ab = _safe_dict(val.get("ability", {}))
+
+    return Joker(
+        key=d.get("key", ""),
+        label=d.get("label", ""),
+        set_=d.get("set", ""),
+        value=JokerValue(
+            effect=val.get("effect", "") or "",
+            rarity=val.get("rarity"),
+            ability=JokerAbility(
+                chips=ab.get("chips"),
+                mult=ab.get("mult"),
+                t_mult=ab.get("t_mult"),
+                t_chips=ab.get("t_chips"),
+                Xmult=ab.get("Xmult"),
+                x_mult=ab.get("x_mult"),
+                s_mult=ab.get("s_mult"),
+                extra=ab.get("extra"),
+                size=ab.get("size"),
+                d_remaining=ab.get("d_remaining"),
+                loyalty_remaining=ab.get("loyalty_remaining"),
+                min=ab.get("min"),
+                max=ab.get("max"),
+                hand_add=ab.get("hand_add"),
+                chip_mod=ab.get("chip_mod"),
+                dollars=ab.get("dollars"),
+                driver_tally=ab.get("driver_tally"),
+                odds=ab.get("odds"),
+            ),
+        ),
+        modifier=CardModifier(
+            enhancement=mod.get("enhancement"),
+            edition=mod.get("edition"),
+            seal=mod.get("seal"),
+            edition_chips=mod.get("edition_chips", 0) or 0,
+            edition_mult=mod.get("edition_mult", 0) or 0,
+            edition_x_mult=mod.get("edition_x_mult", 0) or 0,
+            enhancement_x_mult=mod.get("enhancement_x_mult", 0) or 0,
+        ),
+        state=CardState(debuff=st.get("debuff", False) is True),
+        cost=d.get("cost") or {},
+    )

--- a/src/balatro_bot/domain/models/snapshot.py
+++ b/src/balatro_bot/domain/models/snapshot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from balatro_bot.domain.models.card import Card
+from balatro_bot.domain.models.hand_level import HandLevel
 from balatro_bot.domain.models.joker import Joker
 
 
@@ -38,7 +39,7 @@ class Snapshot:
     round: RoundSnapshot
     current_blind: BlindSnapshot
     hand_cards: list[Card]
-    hand_levels: dict[str, dict]
+    hand_levels: dict[str, HandLevel]
     jokers: list[Joker]
     deck_cards: list[Card]
     consumables: list[Card]

--- a/src/balatro_bot/domain/models/snapshot.py
+++ b/src/balatro_bot/domain/models/snapshot.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from balatro_bot.domain.models.card import Card
+from balatro_bot.domain.models.joker import Joker
+
 
 @dataclass(frozen=True)
 class BlindSnapshot:
@@ -34,12 +37,11 @@ class Snapshot:
     deck_count: int
     round: RoundSnapshot
     current_blind: BlindSnapshot
-    # Raw collections — typed card models deferred to Phase 2
-    hand_cards: list[dict]
+    hand_cards: list[Card]
     hand_levels: dict[str, dict]
-    jokers: list[dict]
-    deck_cards: list[dict]
-    consumables: list[dict]
-    shop_cards: list[dict]
-    vouchers: list[dict]
-    pack_cards: list[dict]
+    jokers: list[Joker]
+    deck_cards: list[Card]
+    consumables: list[Card]
+    shop_cards: list[Card]
+    vouchers: list[Card]
+    pack_cards: list[Card]

--- a/src/balatro_bot/domain/policy/consumable_policy.py
+++ b/src/balatro_bot/domain/policy/consumable_policy.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from balatro_bot.cards import card_rank, card_suit, card_suits, _modifier, rank_value
+from balatro_bot.cards import card_rank, card_suit, card_suits, _modifier, joker_key, rank_value
 from balatro_bot.constants import (
     PLANET_KEYS, SAFE_CONSUMABLE_TAROTS, TARGETING_TAROTS,
     IMMEDIATE_TARGETING, SAFE_SPECTRAL_CONSUMABLES, SPECTRAL_TARGETING,
@@ -147,7 +147,7 @@ def score_consumable(
         if hand_type == "ALL":
             return _BLACK_HOLE_VALUE  # Black Hole — always top priority
         hand_levels = state.get("hands", {})
-        has_constellation = any(j.get("key") == "j_constellation" for j in jokers)
+        has_constellation = any(joker_key(j) == "j_constellation" for j in jokers)
         affinity = strat.hand_affinity(hand_type) if strat else 0.0
         if affinity > 0:
             score = _PLANET_BASE_VALUE + affinity
@@ -226,7 +226,7 @@ def _score_targeting_tarot(
     if effect_type == "enhance":
         base = _ENHANCE_SCORES.get(extra, 2.0)
         jokers = state.get("jokers", {}).get("cards", [])
-        joker_keys = {j.get("key") for j in jokers}
+        joker_keys = {joker_key(j) for j in jokers}
         if extra == "Lucky":
             if "j_lucky_cat" in joker_keys:
                 base += _LUCKY_CAT_BONUS
@@ -243,7 +243,7 @@ def _score_targeting_tarot(
         return remaining_rounds * _DEVIL_INCOME_PER_ROUND / _DEVIL_DIVISOR
 
     if effect_type == "stone":
-        has_stone_joker = any(j.get("key") == "j_stone"
+        has_stone_joker = any(joker_key(j) == "j_stone"
                              for j in state.get("jokers", {}).get("cards", []))
         return _STONE_WITH_JOKER if has_stone_joker else _STONE_WITHOUT_JOKER
 
@@ -272,7 +272,7 @@ def evaluate_hex(jokers: list[dict], ante: int, hand_levels: dict) -> float:
     if len(jokers) <= 1:
         return _HEX_SOLO_VALUE  # 1 joker: free Polychrome
 
-    owned_keys = {j.get("key") for j in jokers}
+    owned_keys = {joker_key(j) for j in jokers}
     # Never use with multiple scaling jokers — losing any is unacceptable
     scaling_count = len(owned_keys & SCALING_JOKERS)
     if scaling_count >= 2:

--- a/src/balatro_bot/domain/policy/discard_policy.py
+++ b/src/balatro_bot/domain/policy/discard_policy.py
@@ -13,6 +13,7 @@ _stream_log = logging.getLogger("balatro_stream")
 from typing import TYPE_CHECKING
 
 from balatro_bot.actions import DiscardCards, Action
+from balatro_bot.cards import joker_key
 from balatro_bot.domain.scoring.estimate import score_hand
 from balatro_bot.domain.scoring.search import (
     best_hand, cards_not_in, discard_candidates, ChaseCandidate,
@@ -84,7 +85,7 @@ def choose_discard(ctx: RoundContext) -> Action | None:
                 )
         return None
 
-    joker_keys = {j.get("key") for j in ctx.jokers}
+    joker_keys = {joker_key(j) for j in ctx.jokers}
 
     # If we have jokers that reward keeping discards, be conservative
     has_keep_discard_jokers = bool(joker_keys & KEEP_DISCARDS_JOKERS)

--- a/src/balatro_bot/domain/policy/pack_policy.py
+++ b/src/balatro_bot/domain/policy/pack_policy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from balatro_bot.cards import joker_key
 from balatro_bot.constants import (
     NO_TARGET_TAROTS, TARGETING_TAROTS, PLANET_HAND_MAP, PLANET_KEYS,
     SCALING_JOKERS, SAFE_SPECTRAL_CONSUMABLES, SPECTRAL_TARGETING,
@@ -150,7 +151,7 @@ def choose_from_buffoon_pack(
 
     from balatro_bot.domain.policy.shop import _is_negative
 
-    owned_keys = {j.get("key") for j in owned_jokers}
+    owned_keys = {joker_key(j) for j in owned_jokers}
     has_madness = "j_madness" in owned_keys
     slots_full = len(owned_jokers) >= joker_limit
 
@@ -240,7 +241,7 @@ def score_spectral_card(
     if score == 0.0:
         return 0.0
 
-    joker_keys = {j.get("key") for j in jokers}
+    joker_keys = {joker_key(j) for j in jokers}
 
     # Apply runtime conditions
     if key in ("c_ankh", "c_hex") and not jokers:

--- a/src/balatro_bot/domain/policy/play_policy.py
+++ b/src/balatro_bot/domain/policy/play_policy.py
@@ -11,7 +11,7 @@ import random
 from typing import TYPE_CHECKING
 
 from balatro_bot.actions import PlayCards, DiscardCards, Action
-from balatro_bot.cards import card_rank, rank_value, _modifier
+from balatro_bot.cards import card_rank, joker_key, rank_value, _modifier
 from balatro_bot.constants import FACE_RANKS_SET
 from balatro_bot.domain.scoring.classify import classify_hand
 from balatro_bot.domain.scoring.estimate import score_hand
@@ -202,7 +202,7 @@ def choose_milk_play(ctx: RoundContext) -> Action | None:
     if ctx.mouth_locked_hand is not None or ctx.blind_name == "The Mouth":
         return None
 
-    joker_keys = {j.get("key") for j in ctx.jokers}
+    joker_keys = {joker_key(j) for j in ctx.jokers}
     owned_scalers = {k: SCALING_REGISTRY[k] for k in joker_keys if k in SCALING_REGISTRY}
     active = {k: p for k, p in owned_scalers.items() if p.milk_priority > 0}
     if not active:

--- a/src/balatro_bot/domain/policy/playing.py
+++ b/src/balatro_bot/domain/policy/playing.py
@@ -5,8 +5,21 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from balatro_bot.actions import Action, SellJoker
-from balatro_bot.cards import is_debuffed
+from balatro_bot.cards import is_debuffed, joker_key
+from balatro_bot.domain.models.joker import Joker
 from balatro_bot.scaling import SELL_PROTECTED
+
+
+def _sell_cost(j: Joker | dict) -> int:
+    if isinstance(j, Joker):
+        return j.cost.get("sell", 99) if isinstance(j.cost, dict) else 99
+    return j.get("cost", {}).get("sell", 99)
+
+
+def _joker_label(j: Joker | dict) -> str:
+    if isinstance(j, Joker):
+        return j.label or "?"
+    return j.get("label", "?")
 
 if TYPE_CHECKING:
     from balatro_bot.context import RoundContext
@@ -31,14 +44,14 @@ def choose_verdant_leaf_unlock(ctx: RoundContext) -> Action | None:
         return None
     candidates = [
         (i, j) for i, j in enumerate(ctx.jokers)
-        if j.get("key") not in SELL_PROTECTED
+        if joker_key(j) not in SELL_PROTECTED
     ]
     if not candidates:
         candidates = list(enumerate(ctx.jokers))
     if not candidates:
         return None
-    sell_idx = min(candidates, key=lambda x: x[1].get("cost", {}).get("sell", 99))[0]
-    label = ctx.jokers[sell_idx].get("label", "?")
+    sell_idx = min(candidates, key=lambda x: _sell_cost(x[1]))[0]
+    label = _joker_label(ctx.jokers[sell_idx])
     return SellJoker(sell_idx, reason=f"Verdant Leaf: sell {label} to unlock debuffed cards")
 
 
@@ -48,7 +61,7 @@ def choose_sell_luchador(ctx: RoundContext) -> Action | None:
         return None
 
     luchador_idx = next(
-        (i for i, j in enumerate(ctx.jokers) if j.get("key") == "j_luchador"), None
+        (i for i, j in enumerate(ctx.jokers) if joker_key(j) == "j_luchador"), None
     )
     if luchador_idx is None:
         return None

--- a/src/balatro_bot/domain/policy/shop.py
+++ b/src/balatro_bot/domain/policy/shop.py
@@ -13,6 +13,7 @@ from balatro_bot.constants import (
     PLANET_KEYS, SAFE_CONSUMABLE_TAROTS, SAFE_SPECTRAL_CONSUMABLES,
     SCALING_JOKERS, SCALING_XMULT, SPECTRAL_TARGETING, TARGETING_TAROTS,
 )
+from balatro_bot.cards import joker_key
 from balatro_bot.joker_effects import JOKER_EFFECTS, _noop, parse_effect_value
 from balatro_bot.domain.policy.shop_valuation import evaluate_joker_value
 from balatro_bot.rules._helpers import evaluate_hex
@@ -127,7 +128,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
 
     # Proactive sell: Popcorn decayed to ≤4 mult
     for i, j in enumerate(owned):
-        if j.get("key") == "j_popcorn":
+        if joker_key(j) == "j_popcorn":
             effect_text = j.get("value", {}).get("effect", "")
             parsed = parse_effect_value(effect_text) if effect_text else {}
             current_mult = parsed.get("mult", 99)
@@ -138,7 +139,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
 
     # Proactive sell: Ramen decayed below X1.0
     for i, j in enumerate(owned):
-        if j.get("key") == "j_ramen":
+        if joker_key(j) == "j_ramen":
             effect_text = j.get("value", {}).get("effect", "")
             parsed = parse_effect_value(effect_text) if effect_text else {}
             current_xmult = parsed.get("xmult")
@@ -173,7 +174,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
         protected = always_protected | SCALING_JOKERS
 
     def _is_stale_scaler(j: dict, cur_ante: int) -> bool:
-        key = j.get("key", "")
+        key = joker_key(j)
         if key not in SCALING_JOKERS or key in always_protected:
             return False
         effect_text = j.get("value", {}).get("effect", "")
@@ -190,7 +191,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
         (i, evaluate_joker_value(j, owned_jokers=owned,
                                  hand_levels=hand_levels, ante=ante, strategy=strat), j)
         for i, j in enumerate(owned)
-        if (j.get("key") not in protected or _is_stale_scaler(j, ante))
+        if (joker_key(j) not in protected or _is_stale_scaler(j, ante))
         and not _is_polychrome(j)  # never sell Polychrome — ×1.5 every hand
     ]
     if not owned_values:
@@ -209,7 +210,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
     best_shop_label = ""
     best_threshold = 0.0
 
-    weakest_key = weakest_joker.get("key", "")
+    weakest_key = joker_key(weakest_joker)
     weakest_on_strategy = any(
         strat.hand_affinity(ht) > 0
         for ht in JOKER_HAND_AFFINITY.get(weakest_key, ([], 0))[0]
@@ -286,7 +287,7 @@ def choose_sell_diet_cola(state: dict[str, Any]) -> Action | None:
     owned = state.get("jokers", {}).get("cards", [])
 
     diet_idx = next(
-        (i for i, j in enumerate(owned) if j.get("key") == "j_diet_cola"), None
+        (i for i, j in enumerate(owned) if joker_key(j) == "j_diet_cola"), None
     )
     if diet_idx is None:
         return None
@@ -304,7 +305,7 @@ def choose_sell_diet_cola(state: dict[str, Any]) -> Action | None:
 def choose_feed_campfire(state: dict[str, Any]) -> Action | None:
     """Sell consumables to feed Campfire's X0.25 Mult per sell."""
     owned_jokers = state.get("jokers", {}).get("cards", [])
-    if not any(j.get("key") == "j_campfire" for j in owned_jokers):
+    if not any(joker_key(j) == "j_campfire" for j in owned_jokers):
         return None
 
     consumables = state.get("consumables", {}).get("cards", [])
@@ -394,7 +395,7 @@ def choose_buy_joker_in_shop(state: dict[str, Any]) -> Action | None:
 
         key = card.get("key", "")
         joker_count = joker_slots.get("count", 0)
-        owned_keys = {j.get("key") for j in joker_slots.get("cards", [])}
+        owned_keys = {joker_key(j) for j in joker_slots.get("cards", [])}
 
         from balatro_bot.scaling import check_anti_synergy
         blocker = check_anti_synergy(key, owned_keys)
@@ -437,8 +438,8 @@ def choose_buy_joker_in_shop(state: dict[str, Any]) -> Action | None:
             value = max(value, 10.0)
             force_buy = True
 
-        if not negative and any(j.get("key") == "j_stencil" for j in joker_slots.get("cards", [])):
-            stencil_count = sum(1 for j in joker_slots.get("cards", []) if j.get("key") == "j_stencil")
+        if not negative and any(joker_key(j) == "j_stencil" for j in joker_slots.get("cards", [])):
+            stencil_count = sum(1 for j in joker_slots.get("cards", []) if joker_key(j) == "j_stencil")
             stencil_mult_after = (jlimit - joker_count - 1) + stencil_count
             if stencil_mult_after <= 2 and value < 5.0:
                 passed_on.append(f"{label}(${cost}, Stencil restriction: only ×{stencil_mult_after} left)")
@@ -593,8 +594,8 @@ def choose_buy_pack_in_shop(state: dict[str, Any]) -> Action | None:
     packs = state.get("packs", {})
     joker_slots = state.get("jokers", {})
     owned_jokers = joker_slots.get("cards", [])
-    has_red_card = any(j.get("key") == "j_red_card" for j in owned_jokers)
-    has_constellation = any(j.get("key") == "j_constellation" for j in owned_jokers)
+    has_red_card = any(joker_key(j) == "j_red_card" for j in owned_jokers)
+    has_constellation = any(joker_key(j) == "j_constellation" for j in owned_jokers)
 
     best_idx = None
     best_priority = 999

--- a/src/balatro_bot/domain/policy/shop_valuation.py
+++ b/src/balatro_bot/domain/policy/shop_valuation.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+from balatro_bot.cards import joker_key
+from balatro_bot.domain.models.card import Card, CardValue
 from balatro_bot.domain.scoring.estimate import score_hand
 from balatro_bot.joker_effects import JOKER_EFFECTS, _noop, parse_effect_value
 from balatro_bot.strategy import (
@@ -128,18 +130,15 @@ _FILLER_RANKS = ["3", "4", "5", "6", "9"]  # ranks unlikely to form pairs
 _STRAIGHT_RANKS = ["5", "6", "7", "8", "9"]
 
 
-def _make_card(rank: str, suit: str) -> dict:
-    """Build a minimal synthetic card dict for scoring simulation."""
-    return {
-        "id": 0,
-        "key": f"{suit}_{rank}",
-        "set": "DEFAULT",
-        "label": f"{rank} of {suit}",
-        "value": {"suit": suit, "rank": rank},
-        "modifier": {},
-        "state": {},
-        "cost": {},
-    }
+def _make_card(rank: str, suit: str) -> Card:
+    """Build a minimal synthetic Card for scoring simulation."""
+    return Card(
+        id=0,
+        key=f"{suit}_{rank}",
+        set_="DEFAULT",
+        label=f"{rank} of {suit}",
+        value=CardValue(rank=rank, suit=suit),
+    )
 
 
 def _preferred_suit(strategy: Strategy | None) -> str:
@@ -432,7 +431,7 @@ def _synergy_multiplier(
     if candidate_hands:
         allies = 0
         for j in owned_jokers:
-            okey = j.get("key", "")
+            okey = joker_key(j)
             if okey == candidate_key or okey not in JOKER_HAND_AFFINITY:
                 continue
             other_hands = set(JOKER_HAND_AFFINITY[okey][0])
@@ -473,7 +472,7 @@ def _context_scale(
     if cat:
         same_count = sum(
             1 for j in owned_jokers
-            if _KEY_TO_CATEGORY.get(j.get("key", "")) == cat
+            if _KEY_TO_CATEGORY.get(joker_key(j)) == cat
         )
         factor *= 1.0 / (1.0 + same_count * 0.25)
 
@@ -501,7 +500,7 @@ def evaluate_joker_value(
     if strategy is None:
         strategy = compute_strategy(owned_jokers, hand_levels)
 
-    owned_keys = {j.get("key") for j in owned_jokers}
+    owned_keys = {joker_key(j) for j in owned_jokers}
 
     # Determine hand types to simulate
     if strategy.preferred_hands:

--- a/src/balatro_bot/domain/scoring/base.py
+++ b/src/balatro_bot/domain/scoring/base.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import math
+from dataclasses import replace
+
+from balatro_bot.domain.models.hand_level import HandLevel
 
 
 # Per-level chip/mult increments for each hand type (fixed in Balatro).
@@ -22,7 +25,7 @@ _HAND_LEVEL_INCREMENTS: dict[str, tuple[int, int]] = {
 }
 
 
-def flint_halve_hand_levels(hand_levels: dict[str, dict]) -> dict[str, dict]:
+def flint_halve_hand_levels(hand_levels: dict) -> dict:
     """Return a copy of hand_levels with chips and mult halved (The Flint).
 
     The Flint halves base chips and mult at scoring time AFTER planet level-ups:
@@ -31,19 +34,25 @@ def flint_halve_hand_levels(hand_levels: dict[str, dict]) -> dict[str, dict]:
     """
     halved = {}
     for hand_name, data in hand_levels.items():
-        if not isinstance(data, dict):
+        if isinstance(data, HandLevel):
+            halved[hand_name] = replace(
+                data,
+                chips=max(math.floor(data.chips * 0.5 + 0.5), 0),
+                mult=max(math.floor(data.mult * 0.5 + 0.5), 1),
+            )
+        elif isinstance(data, dict):
+            d = dict(data)
+            if "chips" in d:
+                d["chips"] = max(math.floor(d["chips"] * 0.5 + 0.5), 0)
+            if "mult" in d:
+                d["mult"] = max(math.floor(d["mult"] * 0.5 + 0.5), 1)
+            halved[hand_name] = d
+        else:
             halved[hand_name] = data
-            continue
-        d = dict(data)
-        if "chips" in d:
-            d["chips"] = max(math.floor(d["chips"] * 0.5 + 0.5), 0)
-        if "mult" in d:
-            d["mult"] = max(math.floor(d["mult"] * 0.5 + 0.5), 1)
-        halved[hand_name] = d
     return halved
 
 
-def arm_reduce_hand_levels(hand_levels: dict[str, dict]) -> dict[str, dict]:
+def arm_reduce_hand_levels(hand_levels: dict) -> dict:
     """Return a copy of hand_levels with each type reduced by 1 level (The Arm).
 
     The Arm decreases the level of the played poker hand by 1 BEFORE scoring.
@@ -54,20 +63,32 @@ def arm_reduce_hand_levels(hand_levels: dict[str, dict]) -> dict[str, dict]:
 
     reduced = {}
     for hand_name, data in hand_levels.items():
-        if not isinstance(data, dict):
-            reduced[hand_name] = data
-            continue
-        d = dict(data)
-        level = d.get("level", 1)
-        if level <= 1:
+        if isinstance(data, HandLevel):
+            if data.level <= 1:
+                reduced[hand_name] = data
+                continue
+            chip_inc, mult_inc = _HAND_LEVEL_INCREMENTS.get(hand_name, (0, 0))
+            base_chips, base_mult, _ = HAND_INFO.get(hand_name, (0, 0, 0))
+            reduced[hand_name] = replace(
+                data,
+                chips=max(data.chips - chip_inc, base_chips),
+                mult=max(data.mult - mult_inc, base_mult),
+                level=data.level - 1,
+            )
+        elif isinstance(data, dict):
+            d = dict(data)
+            level = d.get("level", 1)
+            if level <= 1:
+                reduced[hand_name] = d
+                continue
+            chip_inc, mult_inc = _HAND_LEVEL_INCREMENTS.get(hand_name, (0, 0))
+            base_chips, base_mult, _ = HAND_INFO.get(hand_name, (0, 0, 0))
+            if "chips" in d:
+                d["chips"] = max(d["chips"] - chip_inc, base_chips)
+            if "mult" in d:
+                d["mult"] = max(d["mult"] - mult_inc, base_mult)
+            d["level"] = level - 1
             reduced[hand_name] = d
-            continue
-        chip_inc, mult_inc = _HAND_LEVEL_INCREMENTS.get(hand_name, (0, 0))
-        base_chips, base_mult, _ = HAND_INFO.get(hand_name, (0, 0, 0))
-        if "chips" in d:
-            d["chips"] = max(d["chips"] - chip_inc, base_chips)
-        if "mult" in d:
-            d["mult"] = max(d["mult"] - mult_inc, base_mult)
-        d["level"] = level - 1
-        reduced[hand_name] = d
+        else:
+            reduced[hand_name] = data
     return reduced

--- a/src/balatro_bot/domain/scoring/classify.py
+++ b/src/balatro_bot/domain/scoring/classify.py
@@ -191,10 +191,9 @@ def _straight_scoring_cards(
     # All cards whose rank falls in the window score (including duplicate ranks)
     result = [c for rv, c in ranked if rv in window_set]
 
-    # Append Stone cards
-    result_set = set(id(c) for c in result)
+    # Append Stone cards not already in result
     for c in cards:
-        if is_stone(c) and id(c) not in result_set:
+        if is_stone(c) and not any(c is r for r in result):
             result.append(c)
 
     return result
@@ -230,18 +229,15 @@ def _scoring_cards_for(
                     or _straight_scoring_cards(cards, four_fingers=True, shortcut=shortcut)
                     or []
                 )
-                scored_ids = set(id(c) for c in straight_cards)
                 # Add any flush-subset cards not already in the straight set
                 flush_cards = _flush_scoring_cards(cards, smeared=smeared, four_fingers=True)
                 for c in flush_cards:
-                    if id(c) not in scored_ids:
+                    if not any(c is s for s in straight_cards):
                         straight_cards.append(c)
-                        scored_ids.add(id(c))
                 # Add Stone cards
                 for c in cards:
-                    if is_stone(c) and id(c) not in scored_ids:
+                    if is_stone(c) and not any(c is s for s in straight_cards):
                         straight_cards.append(c)
-                        scored_ids.add(id(c))
                 return straight_cards or list(cards)
             # Plain Flush with four_fingers: only the 4 flush-suit cards score.
             suited = [c for c in cards if not is_stone(c)]
@@ -305,9 +301,8 @@ def _scoring_cards_for(
         ranked.sort(key=lambda c: rank_value(card_rank(c)), reverse=True)
         result = ranked[:1] if ranked else cards[:1]
 
-    result_set = set(id(c) for c in result)
     for c in cards:
-        if is_stone(c) and id(c) not in result_set:
+        if is_stone(c) and not any(c is r for r in result):
             result.append(c)
 
     return result

--- a/src/balatro_bot/domain/scoring/estimate.py
+++ b/src/balatro_bot/domain/scoring/estimate.py
@@ -52,7 +52,7 @@ def _apply_before_phase(scoring_cards, played_cards, jokers):
     current_xmult = _ab_xmult(vampire, fallback=1.0)
 
     enhanced_count = 0
-    orig_to_stripped = {}
+    stripped_pairs = []  # (original_card, stripped_card) for remapping played_cards
     stripped_scoring = []
     for card in scoring_cards:
         mod = _modifier(card)
@@ -63,16 +63,19 @@ def _apply_before_phase(scoring_cards, played_cards, jokers):
             mod_copy = dict(mod)
             mod_copy.pop("enhancement", None)
             card_copy["modifier"] = mod_copy
-            orig_to_stripped[id(card)] = card_copy
+            stripped_pairs.append((card, card_copy))
             stripped_scoring.append(card_copy)
         else:
             stripped_scoring.append(card)
 
     stripped_played = played_cards
     if enhanced_count > 0 and played_cards is not None:
-        stripped_played = [
-            orig_to_stripped.get(id(c), c) for c in played_cards
-        ]
+        def _get_stripped(c):
+            for orig, stripped in stripped_pairs:
+                if c is orig:
+                    return stripped
+            return c
+        stripped_played = [_get_stripped(c) for c in played_cards]
 
     vampire_xmult = current_xmult + extra * enhanced_count if enhanced_count > 0 else current_xmult
     return stripped_scoring, stripped_played, vampire_xmult
@@ -88,11 +91,10 @@ def _apply_card_scoring(ctx, scoring_cards, played_cards, jokers, ancient_suit):
     from balatro_bot.joker_effects import retrigger_count
     from balatro_bot.constants import FACE_RANKS, FIBONACCI_RANKS, EVEN_RANKS, ODD_RANKS
 
-    scoring_id_set = set(id(c) for c in scoring_cards)
-    scored_in_play_order = [c for c in (played_cards or scoring_cards) if id(c) in scoring_id_set]
-    played_id_set = set(id(c) for c in scored_in_play_order)
+    scored_in_play_order = [c for c in (played_cards or scoring_cards)
+                            if any(c is s for s in scoring_cards)]
     for c in scoring_cards:
-        if id(c) not in played_id_set:
+        if not any(c is p for p in scored_in_play_order):
             scored_in_play_order.append(c)
 
     _per_card = []

--- a/src/balatro_bot/domain/scoring/estimate.py
+++ b/src/balatro_bot/domain/scoring/estimate.py
@@ -349,7 +349,7 @@ def ox_most_played_hand(hand_levels: dict) -> str | None:
     best_hand = None
     best_count = 0
     for ht, info in hand_levels.items():
-        if isinstance(info, dict):
+        if hasattr(info, "get"):
             played = info.get("played", 0)
             if played > best_count:
                 best_count = played

--- a/src/balatro_bot/domain/scoring/estimate.py
+++ b/src/balatro_bot/domain/scoring/estimate.py
@@ -28,57 +28,92 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-def _apply_before_phase(scoring_cards, played_cards, jokers):
+def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
     """Simulate the game's 'before' phase — jokers that fire before card scoring.
 
-    Vampire: strips enhancement from enhanced scoring cards, gains xmult.
-    Returns (modified_scoring_cards, modified_played_cards, vampire_xmult).
-    The played_cards list is updated so that stripped scoring cards replace
-    their originals (needed for id()-based matching in _apply_card_scoring).
-    """
-    vampire = None
-    for j in (jokers or []):
-        if j.get("key") == "j_vampire" and not is_joker_debuffed(j):
-            vampire = j
-            break
-    if not vampire:
-        return scoring_cards, played_cards, None
+    In the Lua source (state_events.lua:637), context.before iterates jokers
+    left-to-right. Both Midas Mask (card.lua:3783) and Vampire (card.lua:3805)
+    fire in this phase, mutating cards in-place. Their relative order matters:
 
+      Midas LEFT of Vampire: Midas sets face cards to GOLD, then Vampire
+        strips GOLD (and all other enhancements), gaining xmult for them.
+      Vampire LEFT of Midas: Vampire strips existing enhancements first,
+        then Midas sets face cards to GOLD (they keep GOLD for card scoring).
+
+    This function iterates jokers in list order to match the game's behavior.
+    Returns (modified_scoring_cards, modified_played_cards, vampire_xmult).
+    Callers must update ctx.scoring_cards with the returned cards so that
+    joker_main effects (Flower Pot, Seeing Double, etc.) see the correct
+    post-before-phase enhancement state.
+    """
     from balatro_bot.cards import is_debuffed, _modifier
     from balatro_bot.joker_effects.parsers import _ability, _ab_xmult
+    from balatro_bot.constants import FACE_RANKS
 
-    ab = _ability(vampire)
-    extra = ab.get("extra", 0.1)
-    current_xmult = _ab_xmult(vampire, fallback=1.0)
+    before_jokers = []
+    for j in (jokers or []):
+        if is_joker_debuffed(j):
+            continue
+        key = j.get("key", "")
+        if key in ("j_midas_mask", "j_vampire"):
+            before_jokers.append((key, j))
 
-    enhanced_count = 0
-    stripped_pairs = []  # (original_card, stripped_card) for remapping played_cards
-    stripped_scoring = []
-    for card in scoring_cards:
-        mod = _modifier(card)
-        enhancement = mod.get("enhancement", "")
-        if enhancement and enhancement != "BASE" and not is_debuffed(card):
-            enhanced_count += 1
-            card_copy = dict(card)
-            mod_copy = dict(mod)
-            mod_copy.pop("enhancement", None)
-            card_copy["modifier"] = mod_copy
-            stripped_pairs.append((card, card_copy))
-            stripped_scoring.append(card_copy)
-        else:
-            stripped_scoring.append(card)
+    if not before_jokers:
+        return scoring_cards, played_cards, None
 
-    stripped_played = played_cards
-    if enhanced_count > 0 and played_cards is not None:
-        def _get_stripped(c):
-            for orig, stripped in stripped_pairs:
+    # Work on copies so we don't mutate the caller's lists
+    effective = list(scoring_cards)
+    remap = {}  # original card -> modified card (for played_cards remapping)
+    vampire_xmult = None
+
+    for key, j in before_jokers:
+        if key == "j_midas_mask":
+            # Midas: convert all face cards to GOLD enhancement (card.lua:3786-3788)
+            for i, card in enumerate(effective):
+                rank = card_rank(card)
+                if rank and (pareidolia or rank in FACE_RANKS):
+                    mod = _modifier(card)
+                    if not isinstance(mod, dict) or mod.get("enhancement") == "GOLD":
+                        continue
+                    card_copy = dict(card)
+                    mod_copy = dict(mod) if isinstance(mod, dict) else {}
+                    mod_copy["enhancement"] = "GOLD"
+                    card_copy["modifier"] = mod_copy
+                    remap[id(effective[i])] = (effective[i], card_copy)
+                    effective[i] = card_copy
+
+        elif key == "j_vampire":
+            # Vampire: strip all non-BASE enhancements, gain xmult (card.lua:3805-3833)
+            ab = _ability(j)
+            extra = ab.get("extra", 0.1)
+            current_xmult = _ab_xmult(j, fallback=1.0)
+            enhanced_count = 0
+
+            for i, card in enumerate(effective):
+                mod = _modifier(card)
+                enhancement = mod.get("enhancement", "")
+                if enhancement and enhancement != "BASE" and not is_debuffed(card):
+                    enhanced_count += 1
+                    card_copy = dict(card)
+                    mod_copy = dict(mod)
+                    mod_copy.pop("enhancement", None)
+                    card_copy["modifier"] = mod_copy
+                    remap[id(effective[i])] = (effective[i], card_copy)
+                    effective[i] = card_copy
+
+            vampire_xmult = current_xmult + extra * enhanced_count if enhanced_count > 0 else current_xmult
+
+    # Remap played_cards to reference the modified copies
+    effective_played = played_cards
+    if remap and played_cards is not None:
+        def _get_remapped(c):
+            for _orig_id, (orig, replacement) in remap.items():
                 if c is orig:
-                    return stripped
+                    return replacement
             return c
-        stripped_played = [_get_stripped(c) for c in played_cards]
+        effective_played = [_get_remapped(c) for c in played_cards]
 
-    vampire_xmult = current_xmult + extra * enhanced_count if enhanced_count > 0 else current_xmult
-    return stripped_scoring, stripped_played, vampire_xmult
+    return effective, effective_played, vampire_xmult
 
 
 def _apply_card_scoring(ctx, scoring_cards, played_cards, jokers, ancient_suit):
@@ -161,19 +196,6 @@ def _apply_card_scoring(ctx, scoring_cards, played_cards, jokers, ancient_suit):
                     _add_per_card_effect(target.get("key", ""), target)
         else:
             _add_per_card_effect(k, j)
-
-    _has_midas = any(j.get("key") == "j_midas_mask" for j in (jokers or []))
-    if _has_midas:
-        for i, card in enumerate(scored_in_play_order):
-            rank = card_rank(card)
-            if rank and (ctx.pareidolia or rank in FACE_RANKS):
-                mod = _modifier(card)
-                if isinstance(mod, dict) and mod.get("enhancement") not in (None, "", "GOLD"):
-                    card_copy = dict(card)
-                    mod_copy = dict(mod)
-                    mod_copy["enhancement"] = "GOLD"
-                    card_copy["modifier"] = mod_copy
-                    scored_in_play_order[i] = card_copy
 
     for card in scored_in_play_order:
         triggers = retrigger_count(card, ctx)
@@ -402,8 +424,10 @@ def score_hand(
     )
 
     effective_scoring, effective_played, vampire_xmult = _apply_before_phase(
-        scoring_cards, played_cards, jokers)
+        scoring_cards, played_cards, jokers, pareidolia=ctx.pareidolia)
     ctx.vampire_xmult = vampire_xmult
+    ctx.scoring_cards = effective_scoring
+    ctx.played_cards = effective_played or ctx.played_cards
 
     _apply_card_scoring(ctx, effective_scoring, effective_played, jokers, ancient_suit)
 
@@ -508,8 +532,10 @@ def score_hand_detailed(
     )
 
     effective_scoring, effective_played, vampire_xmult = _apply_before_phase(
-        scoring_cards, played_cards, jokers)
+        scoring_cards, played_cards, jokers, pareidolia=ctx.pareidolia)
     ctx.vampire_xmult = vampire_xmult
+    ctx.scoring_cards = effective_scoring
+    ctx.played_cards = effective_played or ctx.played_cards
 
     _apply_card_scoring(ctx, effective_scoring, effective_played, jokers, ancient_suit)
 

--- a/src/balatro_bot/domain/scoring/estimate.py
+++ b/src/balatro_bot/domain/scoring/estimate.py
@@ -67,7 +67,7 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
 
     # Work on copies so we don't mutate the caller's lists
     effective = list(scoring_cards)
-    remap = {}  # original card -> modified card (for played_cards remapping)
+    remap: list[tuple] = []  # (original, replacement) for played_cards remapping
     vampire_xmult = None
 
     for key, j in before_jokers:
@@ -86,7 +86,7 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
                         mod_copy = dict(mod) if isinstance(mod, dict) else {}
                         mod_copy["enhancement"] = "GOLD"
                         card_copy["modifier"] = mod_copy
-                    remap[id(effective[i])] = (effective[i], card_copy)
+                    remap.append((effective[i], card_copy))
                     effective[i] = card_copy
 
         elif key == "j_vampire":
@@ -108,7 +108,7 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
                         mod_copy = dict(mod)
                         mod_copy.pop("enhancement", None)
                         card_copy["modifier"] = mod_copy
-                    remap[id(effective[i])] = (effective[i], card_copy)
+                    remap.append((effective[i], card_copy))
                     effective[i] = card_copy
 
             vampire_xmult = current_xmult + extra * enhanced_count if enhanced_count > 0 else current_xmult
@@ -117,7 +117,7 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
     effective_played = played_cards
     if remap and played_cards is not None:
         def _get_remapped(c):
-            for _orig_id, (orig, replacement) in remap.items():
+            for orig, replacement in remap:
                 if c is orig:
                     return replacement
             return c

--- a/src/balatro_bot/domain/scoring/estimate.py
+++ b/src/balatro_bot/domain/scoring/estimate.py
@@ -6,6 +6,7 @@ Moved from hand_evaluator.py during Phase 2 of the logic separation refactor.
 from __future__ import annotations
 
 import math
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from balatro_bot.cards import (
@@ -20,9 +21,12 @@ from balatro_bot.cards import (
     is_debuffed,
     is_joker_debuffed,
     is_stone,
+    joker_key,
     rank_value,
 )
 from balatro_bot.constants import HAND_INFO, RANK_CHIPS
+from balatro_bot.domain.models.card import Card
+from balatro_bot.joker_effects.parsers import _ability
 
 if TYPE_CHECKING:
     from typing import Any
@@ -54,7 +58,7 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
     for j in (jokers or []):
         if is_joker_debuffed(j):
             continue
-        key = j.get("key", "")
+        key = joker_key(j)
         if key in ("j_midas_mask", "j_vampire"):
             before_jokers.append((key, j))
 
@@ -73,12 +77,15 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
                 rank = card_rank(card)
                 if rank and (pareidolia or rank in FACE_RANKS):
                     mod = _modifier(card)
-                    if not isinstance(mod, dict) or mod.get("enhancement") == "GOLD":
+                    if mod.get("enhancement") == "GOLD":
                         continue
-                    card_copy = dict(card)
-                    mod_copy = dict(mod) if isinstance(mod, dict) else {}
-                    mod_copy["enhancement"] = "GOLD"
-                    card_copy["modifier"] = mod_copy
+                    if isinstance(card, Card):
+                        card_copy = replace(card, modifier=replace(card.modifier, enhancement="GOLD"))
+                    else:
+                        card_copy = dict(card)
+                        mod_copy = dict(mod) if isinstance(mod, dict) else {}
+                        mod_copy["enhancement"] = "GOLD"
+                        card_copy["modifier"] = mod_copy
                     remap[id(effective[i])] = (effective[i], card_copy)
                     effective[i] = card_copy
 
@@ -94,10 +101,13 @@ def _apply_before_phase(scoring_cards, played_cards, jokers, pareidolia=False):
                 enhancement = mod.get("enhancement", "")
                 if enhancement and enhancement != "BASE" and not is_debuffed(card):
                     enhanced_count += 1
-                    card_copy = dict(card)
-                    mod_copy = dict(mod)
-                    mod_copy.pop("enhancement", None)
-                    card_copy["modifier"] = mod_copy
+                    if isinstance(card, Card):
+                        card_copy = replace(card, modifier=replace(card.modifier, enhancement=None))
+                    else:
+                        card_copy = dict(card)
+                        mod_copy = dict(mod)
+                        mod_copy.pop("enhancement", None)
+                        card_copy["modifier"] = mod_copy
                     remap[id(effective[i])] = (effective[i], card_copy)
                     effective[i] = card_copy
 
@@ -137,7 +147,7 @@ def _apply_card_scoring(ctx, scoring_cards, played_cards, jokers, ancient_suit):
 
     def _add_per_card_effect(key: str, joker: dict) -> None:
         """Add per-card scoring effects for a joker key, using joker's ability data."""
-        ab = joker.get("value", {}).get("ability", {})
+        ab = _ability(joker)
         if key == "j_greedy_joker":
             _per_card.append(("suit_mult", "D", ab.get("s_mult", 3)))
         elif key == "j_lusty_joker":
@@ -181,19 +191,19 @@ def _apply_card_scoring(ctx, scoring_cards, played_cards, jokers, ancient_suit):
     for i, j in enumerate(joker_list):
         if is_joker_debuffed(j):
             continue
-        k = j.get("key", "")
+        k = joker_key(j)
         if k == "j_blueprint":
             # Blueprint copies the joker to its right
             if i + 1 < len(joker_list):
                 target = joker_list[i + 1]
                 if not is_joker_debuffed(target):
-                    _add_per_card_effect(target.get("key", ""), target)
+                    _add_per_card_effect(joker_key(target), target)
         elif k == "j_brainstorm":
             # Brainstorm copies the leftmost joker
             if joker_list and joker_list[0] is not j:
                 target = joker_list[0]
                 if not is_joker_debuffed(target):
-                    _add_per_card_effect(target.get("key", ""), target)
+                    _add_per_card_effect(joker_key(target), target)
         else:
             _add_per_card_effect(k, j)
 
@@ -283,17 +293,17 @@ def _apply_card_scoring(ctx, scoring_cards, played_cards, jokers, ancient_suit):
     for i, j in enumerate(joker_list):
         if is_joker_debuffed(j):
             continue
-        k = j.get("key", "")
+        k = joker_key(j)
         if k == "j_blueprint":
             if i + 1 < len(joker_list):
                 target = joker_list[i + 1]
                 if not is_joker_debuffed(target):
-                    _count_held_phase(target.get("key", ""), target)
+                    _count_held_phase(joker_key(target), target)
         elif k == "j_brainstorm":
             if joker_list and joker_list[0] is not j:
                 target = joker_list[0]
                 if not is_joker_debuffed(target):
-                    _count_held_phase(target.get("key", ""), target)
+                    _count_held_phase(joker_key(target), target)
         else:
             _count_held_phase(k, j)
 
@@ -401,7 +411,7 @@ def score_hand(
         if _ox_locked and hand_name == _ox_locked:
             money = 0
 
-    joker_keys_set = {j.get("key") for j in jokers if not is_joker_debuffed(j)}
+    joker_keys_set = {joker_key(j) for j in jokers if not is_joker_debuffed(j)}
     ctx = ScoreContext(
         chips=base_chips,
         mult=float(base_mult),
@@ -475,13 +485,22 @@ def score_hand_detailed(
 
     card_details = []
     for c in scoring_cards:
-        label = c.get("label", "?")
-        chips = card_chip_value(c)
-        mult = card_mult_value(c)
-        xmult = card_xmult_value(c)
-        mod = c.get("modifier", {})
-        if isinstance(mod, dict) and (mod.get("edition") or mod.get("enhancement")):
-            label += f"[{mod.get('edition','')}/{mod.get('enhancement','')}]"
+        if isinstance(c, Card):
+            label = c.label or "?"
+            chips = card_chip_value(c)
+            mult = card_mult_value(c)
+            xmult = card_xmult_value(c)
+            mod = c.modifier
+            if mod.edition or mod.enhancement:
+                label += f"[{mod.edition or ''}/{mod.enhancement or ''}]"
+        else:
+            label = c.get("label", "?")
+            chips = card_chip_value(c)
+            mult = card_mult_value(c)
+            xmult = card_xmult_value(c)
+            mod = c.get("modifier", {})
+            if isinstance(mod, dict) and (mod.get("edition") or mod.get("enhancement")):
+                label += f"[{mod.get('edition','')}/{mod.get('enhancement','')}]"
         card_details.append((label, chips, mult, xmult))
 
     if not jokers:
@@ -509,7 +528,7 @@ def score_hand_detailed(
             "total": math.floor(total_chips * total_mult),
         }
 
-    joker_keys_set = {j.get("key") for j in jokers if not is_joker_debuffed(j)}
+    joker_keys_set = {joker_key(j) for j in jokers if not is_joker_debuffed(j)}
     ctx = ScoreContext(
         chips=base_chips,
         mult=float(base_mult),

--- a/src/balatro_bot/domain/scoring/search.py
+++ b/src/balatro_bot/domain/scoring/search.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from itertools import combinations
 from typing import NamedTuple
 
-from balatro_bot.cards import card_rank, card_suit, card_suits, is_debuffed, is_joker_debuffed, is_stone, rank_value
+from balatro_bot.cards import card_rank, card_suit, card_suits, is_debuffed, is_joker_debuffed, is_stone, joker_key, rank_value
 from balatro_bot.constants import HAND_INFO
 
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
@@ -88,7 +88,7 @@ def enumerate_hands(
     n = len(hand_cards)
     indices_set = set(range(n))
 
-    joker_keys = {j.get("key") for j in (jokers or []) if not is_joker_debuffed(j)}
+    joker_keys = {joker_key(j) for j in (jokers or []) if not is_joker_debuffed(j)}
     four_fingers = "j_four_fingers" in joker_keys
     has_splash   = "j_splash" in joker_keys
     shortcut     = "j_shortcut" in joker_keys
@@ -224,7 +224,7 @@ def discard_candidates(
     if not bh:
         return [(list(range(min(max_discard, len(hand_cards)))), "no hand found")]
 
-    joker_keys = {j.get("key") for j in (jokers or [])}
+    joker_keys = {joker_key(j) for j in (jokers or [])}
     shortcut = "j_shortcut" in joker_keys
     smeared = "j_smeared" in joker_keys
 
@@ -343,7 +343,7 @@ def discard_candidates(
     strategies.sort(key=chase_score, reverse=True)
 
     results: list[ChaseCandidate] = []
-    has_blackboard = any(j.get("key") == "j_blackboard" for j in (jokers or []))
+    has_blackboard = any(joker_key(j) == "j_blackboard" for j in (jokers or []))
 
     for chase_name, keep, prob, reason in strategies:
         to_discard = cards_not_in(hand_cards, set(keep), blackboard=has_blackboard, rank_affinity=rank_aff)[:max_discard]

--- a/src/balatro_bot/infrastructure/state_adapter.py
+++ b/src/balatro_bot/infrastructure/state_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from balatro_bot.domain.models.card import card_from_dict
+from balatro_bot.domain.models.joker import joker_from_dict
 from balatro_bot.domain.models.snapshot import BlindSnapshot, RoundSnapshot, Snapshot
 
 
@@ -42,12 +44,12 @@ def adapt_state(state: dict) -> Snapshot:
         deck_count=state.get("cards", {}).get("count", 0),
         round=round_snap,
         current_blind=current_blind,
-        hand_cards=state.get("hand", {}).get("cards", []),
+        hand_cards=[card_from_dict(c) for c in state.get("hand", {}).get("cards", [])],
         hand_levels=state.get("hands", {}),
-        jokers=state.get("jokers", {}).get("cards", []),
-        deck_cards=state.get("cards", {}).get("cards", []),
-        consumables=state.get("consumables", {}).get("cards", []),
-        shop_cards=state.get("shop", {}).get("cards", []),
-        vouchers=state.get("vouchers", {}).get("cards", []),
-        pack_cards=state.get("pack", {}).get("cards", []),
+        jokers=[joker_from_dict(j) for j in state.get("jokers", {}).get("cards", [])],
+        deck_cards=[card_from_dict(c) for c in state.get("cards", {}).get("cards", [])],
+        consumables=[card_from_dict(c) for c in state.get("consumables", {}).get("cards", [])],
+        shop_cards=[card_from_dict(c) for c in state.get("shop", {}).get("cards", [])],
+        vouchers=[card_from_dict(c) for c in state.get("vouchers", {}).get("cards", [])],
+        pack_cards=[card_from_dict(c) for c in state.get("pack", {}).get("cards", [])],
     )

--- a/src/balatro_bot/infrastructure/state_adapter.py
+++ b/src/balatro_bot/infrastructure/state_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from balatro_bot.domain.models.card import card_from_dict
+from balatro_bot.domain.models.hand_level import hand_levels_from_dict
 from balatro_bot.domain.models.joker import joker_from_dict
 from balatro_bot.domain.models.snapshot import BlindSnapshot, RoundSnapshot, Snapshot
 
@@ -45,7 +46,7 @@ def adapt_state(state: dict) -> Snapshot:
         round=round_snap,
         current_blind=current_blind,
         hand_cards=[card_from_dict(c) for c in state.get("hand", {}).get("cards", [])],
-        hand_levels=state.get("hands", {}),
+        hand_levels=hand_levels_from_dict(state.get("hands", {})),
         jokers=[joker_from_dict(j) for j in state.get("jokers", {}).get("cards", [])],
         deck_cards=[card_from_dict(c) for c in state.get("cards", {}).get("cards", [])],
         consumables=[card_from_dict(c) for c in state.get("consumables", {}).get("cards", [])],

--- a/src/balatro_bot/joker_effects/complex.py
+++ b/src/balatro_bot/joker_effects/complex.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from balatro_bot.cards import card_rank, card_suits, is_debuffed, _modifier, rank_value
+from balatro_bot.cards import card_rank, card_suit, card_suits, is_debuffed, _modifier, joker_key, rank_value
+from balatro_bot.domain.models.joker import Joker
 from balatro_bot.constants import FACE_RANKS, FIBONACCI_RANKS, EVEN_RANKS, ODD_RANKS, RANK_CHIPS
+from balatro_bot.domain.models.card import Card
 from balatro_bot.joker_effects.parsers import _ability, _ab_chips, _ab_mult, _ab_xmult, _get_parsed_value, _parse_bracket_counter
 from balatro_bot.joker_effects.context import ScoreContext, retrigger_count, _count_suit_in_scoring, _count_face_in_scoring, _hand_contains
 
@@ -24,7 +26,7 @@ def _stencil(ctx: ScoreContext, j: dict) -> None:
     # "X1 Mult for each empty Joker slot. Joker Stencils included."
     # Each Stencil counts all Stencils as empty, not just itself.
     empty_slots = ctx.joker_limit - len(ctx.jokers)
-    stencil_count = sum(1 for jk in ctx.jokers if jk.get("key") == "j_stencil")
+    stencil_count = sum(1 for jk in ctx.jokers if joker_key(jk) == "j_stencil")
     value = empty_slots + stencil_count
     ctx.mult *= max(1, value)
 
@@ -244,7 +246,7 @@ def _flower_pot(ctx: ScoreContext, j: dict) -> None:
             elif enhancement == "STONE":
                 pass  # Stone cards have no suit
             else:
-                suit = c.get("value", {}).get("suit")
+                suit = card_suit(c)
                 if suit in ("H", "D"):
                     red_count += 1
                 elif suit in ("C", "S"):
@@ -271,7 +273,7 @@ def _blueprint(ctx: ScoreContext, j: dict) -> None:
     for i, jk in enumerate(ctx.jokers):
         if jk is j and i + 1 < len(ctx.jokers):
             right = ctx.jokers[i + 1]
-            effect = JOKER_EFFECTS.get(right.get("key", ""))
+            effect = JOKER_EFFECTS.get(joker_key(right))
             if effect and effect is not _blueprint and effect is not _brainstorm:
                 effect(ctx, right)
             break
@@ -281,7 +283,7 @@ def _brainstorm(ctx: ScoreContext, j: dict) -> None:
     if ctx.jokers:
         left = ctx.jokers[0]
         if left is not j:
-            effect = JOKER_EFFECTS.get(left.get("key", ""))
+            effect = JOKER_EFFECTS.get(joker_key(left))
             if effect and effect is not _brainstorm and effect is not _blueprint:
                 effect(ctx, left)
 
@@ -302,7 +304,7 @@ def _bootstraps(ctx: ScoreContext, j: dict) -> None:
 
 def _swashbuckler(ctx: ScoreContext, j: dict) -> None:
     total_sell = sum(
-        other.get("cost", {}).get("sell", 0)
+        (other.cost.get("sell", 0) if isinstance(other, Joker) else other.get("cost", {}).get("sell", 0))
         for other in ctx.jokers if other is not j
     )
     ctx.mult += total_sell
@@ -359,14 +361,14 @@ def _lucky_cat(ctx: ScoreContext, j: dict) -> None:
     from balatro_bot.joker_effects import retrigger_count
     base_xmult = _ab_xmult(j, fallback=1.5)
     extra = _ability(j).get("extra", 0.25)
-    has_oops = any(jk.get("key") == "j_oops" for jk in ctx.jokers)
+    has_oops = any(joker_key(jk) == "j_oops" for jk in ctx.jokers)
     prob = 2 / 5 if has_oops else 1 / 5
     lucky_triggers = sum(
         retrigger_count(c, ctx)
         for c in ctx.scoring_cards
         if not is_debuffed(c)
-        and isinstance(c.get("modifier", {}), dict)
-        and c.get("modifier", {}).get("enhancement") == "LUCKY"
+        and (c.modifier.enhancement if isinstance(c, Card)
+             else _modifier(c).get("enhancement")) == "LUCKY"
     )
     ctx.mult *= base_xmult + extra * prob * lucky_triggers
 

--- a/src/balatro_bot/joker_effects/context.py
+++ b/src/balatro_bot/joker_effects/context.py
@@ -130,9 +130,9 @@ def retrigger_count(card: dict, ctx: ScoreContext) -> int:
         # Hanging Chad retriggers the first PLAYED card that is used in scoring.
         # The game uses played order, not the bot's internal scoring order
         # (which reorders e.g. trips before pairs in Full House).
-        scoring_ids = set(id(c) for c in ctx.scoring_cards)
         first_played_scoring = next(
-            (c for c in ctx.played_cards if id(c) in scoring_ids), None
+            (c for c in ctx.played_cards
+             if any(c is s for s in ctx.scoring_cards)), None
         )
         if first_played_scoring is not None and card is first_played_scoring:
             count += 2

--- a/src/balatro_bot/joker_effects/context.py
+++ b/src/balatro_bot/joker_effects/context.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from balatro_bot.cards import card_rank, card_suits, is_debuffed, _modifier
+from balatro_bot.cards import card_rank, card_suits, is_debuffed, joker_key, _modifier
 from balatro_bot.constants import FACE_RANKS
+from balatro_bot.domain.models.card import Card
+from balatro_bot.domain.models.joker import Joker
 
 if TYPE_CHECKING:
     from typing import Any
+
+    CardLike = Card | dict[str, Any]
+    JokerLike = Joker | dict[str, Any]
 
 
 @dataclass
@@ -17,17 +22,17 @@ class ScoreContext:
     chips: int
     mult: float
     hand_name: str
-    scoring_cards: list[dict]
-    played_cards: list[dict]
-    held_cards: list[dict]
+    scoring_cards: list[CardLike]
+    played_cards: list[CardLike]
+    held_cards: list[CardLike]
     hand_levels: dict
-    jokers: list[dict]
+    jokers: list[JokerLike]
     money: int
     discards_left: int
     hands_left: int
     joker_limit: int = 5
     deck_count: int = 0
-    deck_cards: list[dict] | None = None
+    deck_cards: list[CardLike] | None = None
     pareidolia: bool = False
     smeared: bool = False
     ancient_suit: str | None = None
@@ -113,12 +118,12 @@ def _noop(ctx: ScoreContext, j: dict) -> None:
     pass
 
 
-def retrigger_count(card: dict, ctx: ScoreContext) -> int:
+def retrigger_count(card: Card | dict, ctx: ScoreContext) -> int:
     if is_debuffed(card):
         return 1
     count = 1
     rank = card_rank(card)
-    joker_keys = {j.get("key") for j in ctx.jokers}
+    joker_keys = {joker_key(j) for j in ctx.jokers}
 
     if "j_hack" in joker_keys and rank in ("2", "3", "4", "5"):
         count += 1

--- a/src/balatro_bot/joker_effects/parsers.py
+++ b/src/balatro_bot/joker_effects/parsers.py
@@ -121,17 +121,9 @@ def _parse_bracket_counter(joker: JokerLike) -> int | None:
 def _ability(joker: JokerLike) -> dict:
     """Return the joker's ability as a dict (for backward compat with .get() callers)."""
     if isinstance(joker, Joker):
+        from dataclasses import fields as dc_fields
         ab = joker.value.ability
-        d: dict[str, Any] = {}
-        for field_name in (
-            "chips", "mult", "t_mult", "t_chips", "Xmult", "x_mult", "s_mult",
-            "extra", "size", "d_remaining", "loyalty_remaining", "min", "max",
-            "hand_add", "chip_mod", "dollars", "driver_tally", "odds",
-        ):
-            val = getattr(ab, field_name, None)
-            if val is not None:
-                d[field_name] = val
-        return d
+        return {f.name: v for f in dc_fields(ab) if (v := getattr(ab, f.name)) is not None}
     return joker.get("value", {}).get("ability", {})
 
 

--- a/src/balatro_bot/joker_effects/parsers.py
+++ b/src/balatro_bot/joker_effects/parsers.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+
+from balatro_bot.domain.models.joker import Joker
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    JokerLike = Joker | dict[str, Any]
 
 _CHIPS_PATTERN = re.compile(r'\+(\d+(?:\.\d+)?)\s+Chips')
 _MULT_PATTERN = re.compile(r'\+(\d+(?:\.\d+)?)\s+Mult')
@@ -80,13 +88,20 @@ def parse_effect_value(effect_text: str) -> dict[str, float | None]:
     return result
 
 
-def _get_parsed_value(joker: dict, key: str, fallback: float) -> float:
+def _joker_effect_text(joker: JokerLike) -> str:
+    """Extract effect text from a joker, handling both Joker and dict."""
+    if isinstance(joker, Joker):
+        return joker.value.effect
+    return joker.get("value", {}).get("effect", "")
+
+
+def _get_parsed_value(joker: JokerLike, key: str, fallback: float) -> float:
     """Get a parsed value from joker effect text, falling back to estimate.
 
     key: one of 'chips', 'mult', 'xmult'
     fallback: the hardcoded estimate to use if parsing fails
     """
-    effect_text = joker.get("value", {}).get("effect", "")
+    effect_text = _joker_effect_text(joker)
     if not effect_text:
         return fallback
     parsed = parse_effect_value(effect_text)
@@ -94,21 +109,33 @@ def _get_parsed_value(joker: dict, key: str, fallback: float) -> float:
     return value if value is not None else fallback
 
 
-def _parse_bracket_counter(joker: dict) -> int | None:
+def _parse_bracket_counter(joker: JokerLike) -> int | None:
     """Extract a bracketed counter [N] from effect text (e.g. Yorick's remaining discards)."""
-    effect_text = joker.get("value", {}).get("effect", "")
+    effect_text = _joker_effect_text(joker)
     if not effect_text:
         return None
     m = _BRACKET_COUNTER_PATTERN.search(effect_text)
     return int(m.group(1)) if m else None
 
 
-def _ability(joker: dict) -> dict:
-    """Return the joker's ability dict from the API (empty dict if absent)."""
+def _ability(joker: JokerLike) -> dict:
+    """Return the joker's ability as a dict (for backward compat with .get() callers)."""
+    if isinstance(joker, Joker):
+        ab = joker.value.ability
+        d: dict[str, Any] = {}
+        for field_name in (
+            "chips", "mult", "t_mult", "t_chips", "Xmult", "x_mult", "s_mult",
+            "extra", "size", "d_remaining", "loyalty_remaining", "min", "max",
+            "hand_add", "chip_mod", "dollars", "driver_tally", "odds",
+        ):
+            val = getattr(ab, field_name, None)
+            if val is not None:
+                d[field_name] = val
+        return d
     return joker.get("value", {}).get("ability", {})
 
 
-def _ab_chips(joker: dict, fallback: float = 0) -> float:
+def _ab_chips(joker: JokerLike, fallback: float = 0) -> float:
     """Get chip value from ability data, then text parsing, then fallback."""
     ab = _ability(joker)
     v = ab.get("chips")
@@ -117,7 +144,7 @@ def _ab_chips(joker: dict, fallback: float = 0) -> float:
     return _get_parsed_value(joker, "chips", fallback)
 
 
-def _ab_mult(joker: dict, fallback: float = 0) -> float:
+def _ab_mult(joker: JokerLike, fallback: float = 0) -> float:
     """Get mult value from ability data, then text parsing, then fallback."""
     ab = _ability(joker)
     v = ab.get("mult")
@@ -128,7 +155,7 @@ def _ab_mult(joker: dict, fallback: float = 0) -> float:
     return _get_parsed_value(joker, "mult", fallback)
 
 
-def _ab_xmult(joker: dict, fallback: float = 1.0) -> float:
+def _ab_xmult(joker: JokerLike, fallback: float = 1.0) -> float:
     """Get xmult value from ability data, then text parsing, then fallback."""
     ab = _ability(joker)
     v = ab.get("Xmult")

--- a/src/balatro_bot/joker_effects/registry.py
+++ b/src/balatro_bot/joker_effects/registry.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 
-from balatro_bot.cards import is_joker_debuffed
+from balatro_bot.cards import is_joker_debuffed, joker_key
+from balatro_bot.domain.models.joker import Joker
 from balatro_bot.joker_effects.context import ScoreContext, _noop
 from balatro_bot.joker_effects.simple import SIMPLE_EFFECTS
 from balatro_bot.joker_effects.complex import COMPLEX_EFFECTS
 
+if TYPE_CHECKING:
+    from typing import Any
+
+    JokerLike = Joker | dict[str, Any]
+
 
 # Merge simple and complex effects. Complex takes precedence if both define the same key.
-JOKER_EFFECTS: dict[str, Callable[[ScoreContext, dict], None]] = {}
+JOKER_EFFECTS: dict[str, Callable[[ScoreContext, JokerLike], None]] = {}
 JOKER_EFFECTS.update(SIMPLE_EFFECTS)
 JOKER_EFFECTS.update(COMPLEX_EFFECTS)
 
@@ -66,13 +72,25 @@ for key in (
     JOKER_EFFECTS[key] = _noop
 
 
-def _joker_modifier(joker: dict) -> dict:
-    """Return the modifier dict for a joker, handling [] for empty."""
+def _joker_modifier(joker: JokerLike) -> dict:
+    """Return the modifier dict for a joker, handling both Joker and dict."""
+    if isinstance(joker, Joker):
+        mod = joker.modifier
+        d: dict[str, Any] = {}
+        if mod.edition is not None:
+            d["edition"] = mod.edition
+        if mod.edition_chips:
+            d["edition_chips"] = mod.edition_chips
+        if mod.edition_mult:
+            d["edition_mult"] = mod.edition_mult
+        if mod.edition_x_mult:
+            d["edition_x_mult"] = mod.edition_x_mult
+        return d
     m = joker.get("modifier", {})
     return m if isinstance(m, dict) else {}
 
 
-def _apply_joker_edition_pre(ctx: ScoreContext, joker: dict) -> None:
+def _apply_joker_edition_pre(ctx: ScoreContext, joker: JokerLike) -> None:
     """Apply pre-joker edition effects: Foil (+chips), HOLO (+mult)."""
     mod = _joker_modifier(joker)
     edition = mod.get("edition", "")
@@ -82,7 +100,7 @@ def _apply_joker_edition_pre(ctx: ScoreContext, joker: dict) -> None:
         ctx.mult += mod.get("edition_mult", 10)
 
 
-def _apply_joker_edition_post(ctx: ScoreContext, joker: dict) -> None:
+def _apply_joker_edition_post(ctx: ScoreContext, joker: JokerLike) -> None:
     """Apply post-joker edition effects: Polychrome (xmult).
     Negative has no scoring effect (just +1 slot, already in joker_limit)."""
     mod = _joker_modifier(joker)
@@ -93,8 +111,10 @@ def _apply_joker_edition_post(ctx: ScoreContext, joker: dict) -> None:
         ctx.mult *= mod["edition_x_mult"]
 
 
-def _is_uncommon(joker: dict) -> bool:
+def _is_uncommon(joker: JokerLike) -> bool:
     """Check if a joker is Uncommon rarity (API sends int or string)."""
+    if isinstance(joker, Joker):
+        return joker.value.rarity in (2, "Uncommon")
     rarity = joker.get("value", {}).get("rarity")
     return rarity in (2, "Uncommon")
 
@@ -102,7 +122,7 @@ def _is_uncommon(joker: dict) -> bool:
 def _get_baseball_xmult(ctx: ScoreContext) -> float:
     """Return Baseball Card's xmult if owned, else 0."""
     for j in ctx.jokers:
-        if j.get("key") == "j_baseball":
+        if joker_key(j) == "j_baseball":
             from balatro_bot.joker_effects.parsers import _ability
             return _ability(j).get("extra", 1.5)
     return 0.0
@@ -111,7 +131,7 @@ def _get_baseball_xmult(ctx: ScoreContext) -> float:
 def apply_joker_effects(ctx: ScoreContext) -> None:
     """Apply all owned joker effects to the scoring context, in order.
 
-    Per joker, the game applies: pre-edition → joker effect → post-edition.
+    Per joker, the game applies: pre-edition -> joker effect -> post-edition.
     Baseball Card: after each Uncommon joker fires, apply an additional xMult.
     """
     baseball_xm = _get_baseball_xmult(ctx)
@@ -120,7 +140,7 @@ def apply_joker_effects(ctx: ScoreContext) -> None:
         if is_joker_debuffed(joker):
             continue
         _apply_joker_edition_pre(ctx, joker)
-        key = joker.get("key", "")
+        key = joker_key(joker)
         effect = JOKER_EFFECTS.get(key)
         if effect is not None:
             effect(ctx, joker)
@@ -141,8 +161,8 @@ def apply_joker_effects_detailed(ctx: ScoreContext) -> list[tuple[str, float, fl
     for joker in ctx.jokers:
         if is_joker_debuffed(joker):
             continue
-        key = joker.get("key", "")
-        label = joker.get("label", key)
+        key = joker_key(joker)
+        label = joker.label if isinstance(joker, Joker) else joker.get("label", key)
         pre_chips, pre_mult = ctx.chips, ctx.mult
         _apply_joker_edition_pre(ctx, joker)
         effect = JOKER_EFFECTS.get(key)

--- a/src/balatro_bot/joker_effects/registry.py
+++ b/src/balatro_bot/joker_effects/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Callable, TYPE_CHECKING
 
-from balatro_bot.cards import is_joker_debuffed, joker_key
+from balatro_bot.cards import _modifier, is_joker_debuffed, joker_key
 from balatro_bot.domain.models.joker import Joker
 from balatro_bot.joker_effects.context import ScoreContext, _noop
 from balatro_bot.joker_effects.simple import SIMPLE_EFFECTS
@@ -72,27 +72,9 @@ for key in (
     JOKER_EFFECTS[key] = _noop
 
 
-def _joker_modifier(joker: JokerLike) -> dict:
-    """Return the modifier dict for a joker, handling both Joker and dict."""
-    if isinstance(joker, Joker):
-        mod = joker.modifier
-        d: dict[str, Any] = {}
-        if mod.edition is not None:
-            d["edition"] = mod.edition
-        if mod.edition_chips:
-            d["edition_chips"] = mod.edition_chips
-        if mod.edition_mult:
-            d["edition_mult"] = mod.edition_mult
-        if mod.edition_x_mult:
-            d["edition_x_mult"] = mod.edition_x_mult
-        return d
-    m = joker.get("modifier", {})
-    return m if isinstance(m, dict) else {}
-
-
 def _apply_joker_edition_pre(ctx: ScoreContext, joker: JokerLike) -> None:
     """Apply pre-joker edition effects: Foil (+chips), HOLO (+mult)."""
-    mod = _joker_modifier(joker)
+    mod = _modifier(joker)
     edition = mod.get("edition", "")
     if edition == "FOIL":
         ctx.chips += mod.get("edition_chips", 50)
@@ -103,7 +85,7 @@ def _apply_joker_edition_pre(ctx: ScoreContext, joker: JokerLike) -> None:
 def _apply_joker_edition_post(ctx: ScoreContext, joker: JokerLike) -> None:
     """Apply post-joker edition effects: Polychrome (xmult).
     Negative has no scoring effect (just +1 slot, already in joker_limit)."""
-    mod = _joker_modifier(joker)
+    mod = _modifier(joker)
     edition = mod.get("edition", "")
     if edition == "POLYCHROME":
         ctx.mult *= mod.get("edition_x_mult", 1.5)

--- a/src/balatro_bot/joker_effects/scoring_phase.py
+++ b/src/balatro_bot/joker_effects/scoring_phase.py
@@ -147,16 +147,20 @@ def get_joker_phase(key: str) -> int:
     return _PHASE_MAP.get(key, PHASE_MULT)  # unknown jokers default to +mult (safe middle)
 
 
-def get_joker_edition_phase(joker: dict) -> int:
+def get_joker_edition_phase(joker) -> int:
     """Return the scoring phase implied by a joker's edition (if any).
 
     Foil → chips phase, Holo → mult phase, Polychrome → xmult phase.
     No edition → PHASE_NOOP (no secondary phase).
     """
-    mod = joker.get("modifier", joker.get("value", {}).get("modifier", {}))
-    if isinstance(mod, list):
-        return PHASE_NOOP
-    edition = mod.get("edition", "")
+    from balatro_bot.domain.models.joker import Joker
+    if isinstance(joker, Joker):
+        edition = joker.modifier.edition or ""
+    else:
+        mod = joker.get("modifier", joker.get("value", {}).get("modifier", {}))
+        if isinstance(mod, list):
+            return PHASE_NOOP
+        edition = mod.get("edition", "")
     if edition == "FOIL":
         return PHASE_CHIPS
     if edition in ("HOLO", "HOLOGRAPHIC"):

--- a/src/balatro_bot/rules/_helpers.py
+++ b/src/balatro_bot/rules/_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from balatro_bot.cards import card_rank, card_suit, card_suits, card_xmult_value, card_chip_value, card_mult_value, rank_value, is_debuffed, _modifier
+from balatro_bot.cards import card_rank, card_suit, card_suits, card_xmult_value, card_chip_value, card_mult_value, joker_key, rank_value, is_debuffed, _modifier
 from balatro_bot.constants import (
     FEWER_CARDS_JOKERS, ALL_SCORE_JOKERS, EXACT_4_JOKERS,
     FACE_RANKS, FACE_RANKS_TAROT, PLANET_KEYS, NO_TARGET_TAROTS, TARGETING_TAROTS,
@@ -34,7 +34,7 @@ def _pad_with_junk(
     Card into a Pair, or creating an accidental Flush/Straight).  If we
     can't fill to target without changing the hand, we play fewer cards.
     """
-    joker_keys = {j.get("key") for j in jokers}
+    joker_keys = {joker_key(j) for j in jokers}
     n = len(card_indices)
 
     if joker_keys & FEWER_CARDS_JOKERS and n <= 3:
@@ -103,7 +103,7 @@ def _sort_play_order(
     if len(indices) <= 1:
         return indices
 
-    joker_keys = {j.get("key") for j in jokers}
+    joker_keys = {joker_key(j) for j in jokers}
     has_hanging_chad = "j_hanging_chad" in joker_keys
     has_photograph = "j_photograph" in joker_keys
     has_triboulet = "j_triboulet" in joker_keys
@@ -140,7 +140,7 @@ def _sort_play_order(
             suits = card_suits(c)
             add = card_chip_value(c) + card_mult_value(c)
             for j in jokers:
-                k = j.get("key", "")
+                k = joker_key(j)
                 if k == "j_even_steven" and rank in EVEN_RANKS:
                     add += 4
                 elif k == "j_odd_todd" and rank in ODD_RANKS:
@@ -284,7 +284,7 @@ def _find_glass_targets(hand_cards, count, rank_affinity=None):
 
 
 def _find_stone_targets(hand_cards, count, jokers, rank_affinity=None):
-    has_stone_joker = any(j.get("key") == "j_stone" for j in jokers)
+    has_stone_joker = any(joker_key(j) == "j_stone" for j in jokers)
     candidates = []
     for i, c in enumerate(hand_cards):
         r = card_rank(c)

--- a/src/balatro_bot/rules/consumables.py
+++ b/src/balatro_bot/rules/consumables.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from balatro_bot.actions import UseConsumable, SellConsumable, SellJoker, RearrangeHand, Action
+from balatro_bot.cards import joker_key
 from balatro_bot.constants import (
     PLANET_KEYS, SAFE_CONSUMABLE_TAROTS, TARGETING_TAROTS,
     SAFE_SPECTRAL_CONSUMABLES, SPECTRAL_TARGETING,
@@ -239,7 +240,7 @@ class UseConsumables:
 
         # Verify target joker is still owned
         target_idx = next(
-            (i for i, j in enumerate(jokers) if j.get("key") == self._hex_target_key), None
+            (i for i, j in enumerate(jokers) if joker_key(j) == self._hex_target_key), None
         )
         if target_idx is None:
             self._hex_selling_down = False
@@ -264,7 +265,7 @@ class UseConsumables:
         worst_idx = None
         worst_val = float("inf")
         for i, j in enumerate(jokers):
-            if j.get("key") == self._hex_target_key:
+            if joker_key(j) == self._hex_target_key:
                 continue
             val = evaluate_joker_value(j, jokers, hand_levels, ante, strat)
             if val < worst_val:

--- a/src/balatro_bot/rules/packs.py
+++ b/src/balatro_bot/rules/packs.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from balatro_bot.actions import PackAction, Action
+from balatro_bot.cards import joker_key
 from balatro_bot.constants import (
     NO_TARGET_TAROTS, TARGETING_TAROTS, PLANET_HAND_MAP, PLANET_KEYS,
     SAFE_SPECTRAL_CONSUMABLES, SPECTRAL_TARGETING,
@@ -26,7 +27,7 @@ class SkipPackForRedCard:
 
     def evaluate(self, state: dict[str, Any]) -> Action | None:
         jokers = state.get("jokers", {}).get("cards", [])
-        if not any(j.get("key") == "j_red_card" for j in jokers):
+        if not any(joker_key(j) == "j_red_card" for j in jokers):
             return None
 
         pack = state.get("pack", {})
@@ -103,7 +104,7 @@ class PickFromPlanetPack:
             return None
 
         jokers = state.get("jokers", {}).get("cards", [])
-        joker_keys = {j.get("key") for j in jokers}
+        joker_keys = {joker_key(j) for j in jokers}
         hand_levels = state.get("hands", {})
         strat = compute_strategy(jokers, hand_levels)
 

--- a/src/balatro_bot/rules/shop.py
+++ b/src/balatro_bot/rules/shop.py
@@ -7,6 +7,7 @@ from balatro_bot.actions import (
     BuyCard, BuyPack, BuyVoucher, SellJoker, SellConsumable,
     Reroll, NextRound, RearrangeJokers, Action,
 )
+from balatro_bot.cards import joker_key
 from balatro_bot.context import RoundContext
 from balatro_bot.constants import (
     SCALING_JOKERS, SCALING_XMULT, PLANET_KEYS, SAFE_CONSUMABLE_TAROTS,
@@ -72,7 +73,7 @@ class SellInvisible:
 
     def _score_target(self, joker: dict) -> float:
         """Score how valuable this joker is as a dupe target."""
-        key = joker.get("key", "")
+        key = joker_key(joker)
 
         if key in self.COPY_JOKERS:
             return _COPY_JOKER_DUPE_SCORE
@@ -94,7 +95,7 @@ class SellInvisible:
         for i, j in enumerate(owned):
             if i == invisible_idx:
                 continue
-            if j.get("key", "") not in self._dupe_worthy():
+            if joker_key(j) not in self._dupe_worthy():
                 continue
             score = self._score_target(j)
             if score > best_score:
@@ -122,7 +123,7 @@ class SellInvisible:
         owned = state.get("jokers", {}).get("cards", [])
 
         invisible_idx = next(
-            (i for i, j in enumerate(owned) if j.get("key") == "j_invisible"), None
+            (i for i, j in enumerate(owned) if joker_key(j) == "j_invisible"), None
         )
         if invisible_idx is None:
             self._first_seen_round = None
@@ -264,7 +265,7 @@ class ReorderJokersForScoring:
         fodder: list[int] = []  # noop jokers (candidates for Ceremonial sacrifice)
 
         for i, j in enumerate(owned):
-            key = j.get("key", "")
+            key = joker_key(j)
             phase = get_joker_phase(key)
             if key == "j_ceremonial":
                 ceremonial_idx = i
@@ -286,7 +287,7 @@ class ReorderJokersForScoring:
         for i, j in enumerate(owned):
             if i in excluded:
                 continue
-            key = j.get("key", "")
+            key = joker_key(j)
             phase = get_joker_phase(key)
             ed_phase = get_joker_edition_phase(j)
             sortable.append((i, phase, ed_phase))
@@ -302,13 +303,13 @@ class ReorderJokersForScoring:
             # Always remove Ceremonial from its sorted position first
             desired_order = [i for i in desired_order if i != ceremonial_idx]
             if available_fodder:
-                available_fodder.sort(key=lambda i: owned[i].get("key", ""))
+                available_fodder.sort(key=lambda i: joker_key(owned[i]))
                 sacrifice_idx = available_fodder[0]
                 desired_order = [i for i in desired_order if i != sacrifice_idx]
                 # Insert Ceremonial after the last +mult joker (or after chips)
                 insert_at = 0
                 for pos, idx in enumerate(desired_order):
-                    if get_joker_phase(owned[idx].get("key", "")) <= PHASE_MULT:
+                    if get_joker_phase(joker_key(owned[idx])) <= PHASE_MULT:
                         insert_at = pos + 1
                 desired_order.insert(insert_at, ceremonial_idx)
                 desired_order.insert(insert_at + 1, sacrifice_idx)
@@ -322,7 +323,7 @@ class ReorderJokersForScoring:
             best_target_pos = None
             for pos in range(len(desired_order) - 1, -1, -1):
                 idx = desired_order[pos]
-                key = owned[idx].get("key", "")
+                key = joker_key(owned[idx])
                 if key in ("j_blueprint", "j_brainstorm"):
                     continue
                 phase = get_joker_phase(key)
@@ -333,7 +334,7 @@ class ReorderJokersForScoring:
                 # No ×mult — find rightmost +mult
                 for pos in range(len(desired_order) - 1, -1, -1):
                     idx = desired_order[pos]
-                    key = owned[idx].get("key", "")
+                    key = joker_key(owned[idx])
                     if get_joker_phase(key) == PHASE_MULT:
                         best_target_pos = pos
                         break
@@ -347,11 +348,11 @@ class ReorderJokersForScoring:
             desired_order.append(brainstorm_idx)
             # Ensure position 0 is a good copyable effect (not noop/brainstorm)
             if desired_order:
-                first_key = owned[desired_order[0]].get("key", "")
+                first_key = joker_key(owned[desired_order[0]])
                 first_phase = get_joker_phase(first_key)
                 if first_phase == PHASE_NOOP and len(desired_order) > 1:
                     for swap_pos in range(1, len(desired_order)):
-                        swap_key = owned[desired_order[swap_pos]].get("key", "")
+                        swap_key = joker_key(owned[desired_order[swap_pos]])
                         if (get_joker_phase(swap_key) != PHASE_NOOP
                                 and swap_key != "j_brainstorm"):
                             desired_order[0], desired_order[swap_pos] = \

--- a/src/balatro_bot/strategy.py
+++ b/src/balatro_bot/strategy.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from balatro_bot.cards import joker_key
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -293,7 +295,7 @@ def compute_strategy(
     rank_scores: dict[str, float] = {}
 
     for joker in jokers:
-        key = joker.get("key", "")
+        key = joker_key(joker)
 
         if key in JOKER_HAND_AFFINITY:
             hand_types, weight = JOKER_HAND_AFFINITY[key]
@@ -310,7 +312,7 @@ def compute_strategy(
                 rank_scores[r] = rank_scores.get(r, 0) + weight
 
     # Detect active archetypes and inject their contributions
-    joker_keys = {j.get("key", "") for j in jokers}
+    joker_keys = {joker_key(j) for j in jokers}
     active_archs: list[tuple[str, float]] = []
     for arch in ARCHETYPE_REGISTRY.values():
         members = {k for k in arch.joker_weights if k in joker_keys}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,69 @@
 """Shared test fixtures — card factory helpers."""
 
-
-def card(rank: str, suit: str, enhancement: str | None = None) -> dict:
-    """Build a minimal card dict matching the balatrobot schema."""
-    c: dict = {
-        "id": 0,
-        "key": f"{suit}_{rank}",
-        "set": "DEFAULT",
-        "label": f"{rank} of {suit}",
-        "value": {"suit": suit, "rank": rank},
-        "modifier": {},
-        "state": {},
-        "cost": {},
-    }
-    if enhancement:
-        c["modifier"]["enhancement"] = enhancement
-    return c
+from balatro_bot.domain.models.card import Card, CardModifier, CardState, CardValue
 
 
-def stone_card() -> dict:
-    return {
-        "id": 0, "key": "stone", "set": "ENHANCED", "label": "Stone Card",
-        "value": {}, "modifier": {"enhancement": "STONE"}, "state": {}, "cost": {},
-    }
+def card(rank: str, suit: str, enhancement: str | None = None) -> Card:
+    """Build a minimal Card matching the balatrobot schema."""
+    return Card(
+        id=0,
+        key=f"{suit}_{rank}",
+        set_="DEFAULT",
+        label=f"{rank} of {suit}",
+        value=CardValue(rank=rank, suit=suit),
+        modifier=CardModifier(enhancement=enhancement),
+        state=CardState(),
+        cost={},
+    )
 
 
-def wild_card(rank: str, suit: str) -> dict:
-    c = card(rank, suit)
-    c["modifier"]["enhancement"] = "WILD"
-    return c
+def stone_card() -> Card:
+    return Card(
+        id=0, key="stone", set_="ENHANCED", label="Stone Card",
+        value=CardValue(), modifier=CardModifier(enhancement="STONE"),
+        state=CardState(), cost={},
+    )
+
+
+def wild_card(rank: str, suit: str) -> Card:
+    return Card(
+        id=0,
+        key=f"{suit}_{rank}",
+        set_="DEFAULT",
+        label=f"{rank} of {suit}",
+        value=CardValue(rank=rank, suit=suit),
+        modifier=CardModifier(enhancement="WILD"),
+        state=CardState(),
+        cost={},
+    )
+
+
+def debuffed_card(rank: str, suit: str, enhancement: str | None = None) -> Card:
+    """Build a debuffed Card."""
+    return Card(
+        id=0,
+        key=f"{suit}_{rank}",
+        set_="DEFAULT",
+        label=f"{rank} of {suit}",
+        value=CardValue(rank=rank, suit=suit),
+        modifier=CardModifier(enhancement=enhancement),
+        state=CardState(debuff=True),
+        cost={},
+    )
+
+
+def card_with_perma(rank: str, suit: str, perma_bonus: int, enhancement: str | None = None) -> Card:
+    """Build a Card with perma_bonus."""
+    return Card(
+        id=0,
+        key=f"{suit}_{rank}",
+        set_="DEFAULT",
+        label=f"{rank} of {suit}",
+        value=CardValue(rank=rank, suit=suit, perma_bonus=perma_bonus),
+        modifier=CardModifier(enhancement=enhancement),
+        state=CardState(),
+        cost={},
+    )
 
 
 def joker(key: str, label: str = "") -> dict:

--- a/tests/integration/test_acrobat.py
+++ b/tests/integration/test_acrobat.py
@@ -14,80 +14,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None, hands_left=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    # Set hands_left to force last-hand condition
-    if hands_left is not None:
-        try:
-            client.call("set", {"hands": hands_left})
-        except APIError as e:
-            print(f"  FAILED to set hands={hands_left}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def run_test(client, label, seed, joker_keys, hands_left=None, hand=None):
@@ -231,6 +165,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:50s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_baseball.py
+++ b/tests/integration/test_baseball.py
@@ -11,74 +11,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, card_mult_value, _modifier
 
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hand_cards = state.get("hand", {}).get("cards", [])
-        if hand_cards:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hand_cards), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def play_and_compare(client, state, play_indices, label=""):
@@ -266,6 +206,12 @@ def main():
         mg = actual_mult - r["mult"] if r["chips"] else 0
         status = "" if r["diff"] == 0 else f"{mg:+.1f}"
         print(f"  {r['label']:50s} {r['est']:8d} {r['actual']:8d} {r['diff']:+8d} {status:>8s}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_baseball_order.py
+++ b/tests/integration/test_baseball_order.py
@@ -15,68 +15,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def run_test(client, label, seed, joker_keys, hand=None):
@@ -270,6 +216,12 @@ def main():
             print(f"  >> ORDER MATTERS (diff={t5['actual'] - t6['actual']})")
         else:
             print(f"  >> Order does NOT matter (same score)")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_batch069_fixes.py
+++ b/tests/integration/test_batch069_fixes.py
@@ -29,7 +29,8 @@ from balatro_bot.cards import _modifier, card_rank, card_suits, is_joker_debuffe
 
 from harness import (
     TEST_PORT, BOSS_MIN_ANTE,
-    wait_for_state, setup_game, get_current_blind,
+    wait_for_state, setup_game, setup_game_full as setup_clean,
+    get_current_blind,
     advance_to_boss_select, advance_through_post_blind,
     force_boss, inject_jokers, set_ante, beat_blind_fast,
     ensure_server, stop_server, take_screenshot,
@@ -40,59 +41,6 @@ from scoring_diagnostics import fmt_card, dump_hand_detail
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def setup_clean(client, seed, joker_keys=None, card_configs=None):
-    """Start fresh game, sell default jokers, discard hand, inject jokers + cards."""
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-
-    client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, {"SELECTING_HAND"})
-
-    # Sell default jokers
-    for _ in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    # Discard hand twice to clear starting cards
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    # Inject jokers
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    # Inject playing cards
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def play_and_compare(client, state, play_indices, label="", blind_name="",

--- a/tests/integration/test_blackboard.py
+++ b/tests/integration/test_blackboard.py
@@ -14,73 +14,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def run_test(client, label, seed, joker_keys, hand, play_count=None):
@@ -307,6 +247,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:55s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_cavendish.py
+++ b/tests/integration/test_cavendish.py
@@ -16,74 +16,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_mult, _ab_xmult
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def dump_jokers(jokers):
@@ -290,6 +230,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:55s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_flint_luchador.py
+++ b/tests/integration/test_flint_luchador.py
@@ -574,6 +574,8 @@ def main():
             print("Use --start-server to auto-launch, or start one manually.")
             sys.exit(1)
 
+    result = None
+    engine_result = None
     try:
         if not args.engine_only:
             # Test 1: Controlled Flint + Luchador lifecycle
@@ -581,6 +583,30 @@ def main():
 
         # Test 2: Engine mode (production loop replication)
         engine_result = run_engine_mode_test(client, seed=args.seed + "2")
+
+        # --- Mismatch assertions ---
+        failures = []
+
+        if not args.engine_only and result is not None:
+            if result["h1_diff"] != 0:
+                failures.append(f"Hand #1 (Flint active): diff={result['h1_diff']:+d}")
+            if result["h2_diff_disabled"] != 0:
+                failures.append(f"Hand #2 (Flint disabled): diff={result['h2_diff_disabled']:+d}")
+
+        # Engine mode doesn't compute estimate diffs inline, so a None result
+        # (test aborted) is the main failure signal from that test.
+
+        if result is None and not args.engine_only:
+            failures.append("run_flint_luchador_test aborted (returned None)")
+        if engine_result is None:
+            failures.append("run_engine_mode_test aborted (returned None)")
+
+        if failures:
+            print(f"\nFAILED: {len(failures)} failure(s)")
+            for f in failures:
+                print(f"  - {f}")
+            sys.exit(1)
+        print("\nPASSED: all scores matched")
 
     finally:
         if server_proc:

--- a/tests/integration/test_flint_vampire.py
+++ b/tests/integration/test_flint_vampire.py
@@ -21,81 +21,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
+from harness import wait_for_state, setup_game_full as setup_game
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_xmult
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        if gs == "SHOP":
-            client.call("next_round")
-            time.sleep(0.3)
-            continue
-        if gs in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "ROUND_EVAL"):
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def get_current_blind(state):
@@ -645,6 +578,12 @@ def main():
         print(f"  {r['label']:50s} est={r['est']:>6d} actual={r['actual']:>6d} {status}{floor_ok}")
 
     print(f"\n  Total: {matches} match, {mismatches} mismatch out of {matches + mismatches}")
+
+    mismatches = [r for r in all_results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_flint_vampire_v2.py
+++ b/tests/integration/test_flint_vampire_v2.py
@@ -21,6 +21,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 _venv_sp = os.path.join(os.path.dirname(__file__), "..", "..", ".venv", "Lib", "site-packages")
 if os.path.isdir(_venv_sp) and _venv_sp not in sys.path:
     sys.path.insert(0, os.path.abspath(_venv_sp))
@@ -32,6 +33,8 @@ from balatro_bot.domain.scoring.base import flint_halve_hand_levels
 from balatro_bot.cards import card_chip_value, _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_xmult
 
+from harness import wait_for_state
+
 # Lazy-imported: harness eagerly validates config paths at import time,
 # which fails if BALATRO_EXE isn't set.  Only needed for --start-server.
 # from harness import TEST_PORT, ensure_server, stop_server
@@ -40,28 +43,6 @@ from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_
 # =========================================================================
 # Helpers
 # =========================================================================
-
-def wait_for_state(client, target_states, max_tries=30):
-    state = {}
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        if gs == "SHOP":
-            client.call("next_round")
-            time.sleep(0.3)
-            continue
-        if gs in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "ROUND_EVAL"):
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
 
 def get_current_blind(state):
     for b in state.get("blinds", {}).values():
@@ -654,8 +635,7 @@ def main():
         if server_proc:
             _stop(server_proc)
 
-    if mismatches > 0:
-        sys.exit(1)
+    assert mismatches == 0, f"{mismatches} scoring mismatch(es) — see SUMMARY above"
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_glass_poly.py
+++ b/tests/integration/test_glass_poly.py
@@ -20,26 +20,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_xmult_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    """Poll until game reaches one of the target states."""
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
+from harness import wait_for_state
 
 
 def main():

--- a/tests/integration/test_holo_edition.py
+++ b/tests/integration/test_holo_edition.py
@@ -20,26 +20,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, card_mult_value, card_xmult_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    """Poll until game reaches one of the target states."""
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
+from harness import wait_for_state
 
 
 def dump_card(i, c):
@@ -269,6 +256,12 @@ def main():
 
     print(f"\nCheck the lovely console for BB.EDITION debug messages!")
     print("Look for: raw_edition={{...}} to see if card.edition.mult is contaminated")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_hologram.py
+++ b/tests/integration/test_hologram.py
@@ -18,12 +18,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_xmult
+from harness import wait_for_state
 
 
 # ── helpers ──────────────────────────────────────────────────────
@@ -49,25 +51,6 @@ def beat_blind_fast(client):
         except APIError:
             pass
     time.sleep(0.5)
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-        elif gs == "SHOP":
-            client.call("next_round")
-            time.sleep(0.3)
-        elif gs in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "ROUND_EVAL"):
-            time.sleep(0.3)
-        else:
-            time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
 
 
 def wait_for_one(client, target_state, max_tries=30):
@@ -508,6 +491,12 @@ def main():
         print(f"  DNA hands:      {dm}/{len(dna_results)} match")
         if dm < len(dna_results):
             print(f"    >>> DNA mid-scoring increment causes stale snapshot")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_mismatch_lift.py
+++ b/tests/integration/test_mismatch_lift.py
@@ -17,74 +17,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
+from harness import wait_for_state, setup_game_full as setup_game
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_mult, _ab_xmult
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def dump_jokers(jokers):
@@ -560,6 +500,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:55s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_mult_holo.py
+++ b/tests/integration/test_mult_holo.py
@@ -18,73 +18,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, card_mult_value, card_edition_mult_value, card_xmult_value, card_edition_xmult_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def dump_card(card):
@@ -221,6 +161,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:55s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_ox.py
+++ b/tests/integration/test_ox.py
@@ -27,7 +27,8 @@ from balatro_bot.cards import is_joker_debuffed
 
 from harness import (
     TEST_PORT,
-    wait_for_state, get_current_blind,
+    wait_for_state, setup_game_full as setup_clean,
+    get_current_blind,
     advance_to_boss_select, force_boss,
     beat_blind_fast, cheat_win_if_needed,
     ensure_server, stop_server, take_screenshot,
@@ -38,55 +39,6 @@ from scoring_diagnostics import fmt_card
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def setup_clean(client, seed, joker_keys=None, card_configs=None):
-    """Start fresh game, sell default jokers, discard hand, inject jokers + cards."""
-    try:
-        client.call("menu")
-    except Exception:
-        pass
-    time.sleep(0.5)
-
-    client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, {"SELECTING_HAND"})
-
-    for _ in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def play_and_compare(client, state, play_indices, label="", blind_name="",

--- a/tests/integration/test_percard_scoring.py
+++ b/tests/integration/test_percard_scoring.py
@@ -14,68 +14,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def run_test(client, label, seed, joker_keys, hand_configs, play_count=None):
@@ -289,6 +234,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:55s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
     # Key comparisons
     print(f"\n  KEY COMPARISONS:")

--- a/tests/integration/test_rearrange.py
+++ b/tests/integration/test_rearrange.py
@@ -14,8 +14,10 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
+from harness import wait_for_state
 
 
 # ── helpers ──────────────────────────────────────────────────────
@@ -25,25 +27,6 @@ def give_money(client, amount=9999):
         client.call("set", {"money": amount})
     except APIError:
         pass
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-        elif gs in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "ROUND_EVAL"):
-            time.sleep(0.3)
-        elif gs == "SHOP":
-            client.call("next_round")
-            time.sleep(0.3)
-        else:
-            time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
 
 
 def advance_to_shop(client, max_tries=40):

--- a/tests/integration/test_scoring_053.py
+++ b/tests/integration/test_scoring_053.py
@@ -15,25 +15,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, card_mult_value, card_xmult_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def dump_card(i, c):
@@ -43,61 +31,6 @@ def dump_card(i, c):
     enh = mod.get("enhancement", "-")
     ed = mod.get("edition", "-")
     print(f"  [{i}] {rank}{suit} enh={enh} ed={ed} | chips={card_chip_value(c)} mult={card_mult_value(c)} | raw_mod={mod}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    """Start fresh game, sell existing jokers, discard hand, inject jokers + cards."""
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    # Sell all existing jokers
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    # Discard hand twice to clear
-    for _ in range(2):
-        state = client.call("gamestate")
-        hand_cards = state.get("hand", {}).get("cards", [])
-        if hand_cards:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hand_cards), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    # Inject jokers
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-                print(f"  Added joker: {params.get('key')}")
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    # Inject playing cards
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def play_and_compare(client, state, play_indices, label=""):
@@ -578,6 +511,12 @@ def main():
             mismatches += 1
         print(f"  {r['label']:45s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
     print(f"\n  Total: {matches + mismatches} tests, {matches} matches, {mismatches} mismatches")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_scoring_bugs.py
+++ b/tests/integration/test_scoring_bugs.py
@@ -14,25 +14,13 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, card_mult_value, card_xmult_value, _modifier
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def dump_card(i, c):
@@ -42,61 +30,6 @@ def dump_card(i, c):
     enh = mod.get("enhancement", "-")
     ed = mod.get("edition", "-")
     print(f"  [{i}] {rank}{suit} enh={enh} ed={ed} | chips={card_chip_value(c)} mult={card_mult_value(c)} | raw_mod={mod}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    """Start fresh game, sell existing jokers, discard hand, inject jokers + cards."""
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    # Sell all existing jokers
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    # Discard hand twice to clear
-    for _ in range(2):
-        state = client.call("gamestate")
-        hand_cards = state.get("hand", {}).get("cards", [])
-        if hand_cards:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hand_cards), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    # Inject jokers
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-                print(f"  Added joker: {params.get('key')}")
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    # Inject playing cards
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def play_and_compare(client, state, play_indices, label=""):
@@ -531,6 +464,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:45s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_shortcut_edges.py
+++ b/tests/integration/test_shortcut_edges.py
@@ -34,64 +34,12 @@ from balatro_bot.cards import _modifier, card_rank, card_suits, is_joker_debuffe
 
 from harness import (
     TEST_PORT,
-    wait_for_state, get_current_blind,
+    wait_for_state, setup_game_full as setup_clean,
+    get_current_blind,
     ensure_server, stop_server, take_screenshot,
 )
 from scoring_diagnostics import fmt_card
 
-
-# ---------------------------------------------------------------------------
-# Helpers (same pattern as test_batch069_fixes.py)
-# ---------------------------------------------------------------------------
-
-def setup_clean(client, seed, joker_keys=None, card_configs=None):
-    """Start fresh game, sell default jokers, discard hand, inject jokers + cards."""
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-
-    client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, {"SELECTING_HAND"})
-
-    for _ in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
 
 
 def play_and_compare(client, state, play_indices, label="", blind_name=""):

--- a/tests/integration/test_smaller_issues.py
+++ b/tests/integration/test_smaller_issues.py
@@ -14,80 +14,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_mult, _ab_xmult
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None, hands_left=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    state = client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    if hands_left is not None:
-        try:
-            client.call("set", {"hands": hands_left})
-        except APIError as e:
-            print(f"  FAILED to set hands={hands_left}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def _score_and_play(client, state, hand_size):
@@ -560,6 +494,12 @@ def main():
             continue
         status = "MATCH" if r["diff"] == 0 else f"MISMATCH({r['diff']:+d})"
         print(f"  {r['label']:55s} est={r['est']:>8d} actual={r['actual']:>8d} {status}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_steel_joker.py
+++ b/tests/integration/test_steel_joker.py
@@ -24,81 +24,14 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 
 from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
 from balatro_bot.domain.scoring.estimate import score_hand_detailed
 from balatro_bot.cards import card_chip_value, _modifier
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_xmult
-
-
-def wait_for_state(client, target_states, max_tries=30):
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        if gs == "SHOP":
-            client.call("next_round")
-            time.sleep(0.3)
-            continue
-        if gs in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "ROUND_EVAL"):
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
-
-def setup_game(client, seed, joker_keys=None, card_configs=None):
-    try:
-        client.call("menu")
-    except APIError:
-        pass
-    time.sleep(0.5)
-    client.call("start", {"deck": "RED", "stake": "WHITE", "seed": seed})
-    state = wait_for_state(client, ["SELECTING_HAND"])
-
-    for i in range(state.get("jokers", {}).get("count", 0)):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    for _ in range(2):
-        state = client.call("gamestate")
-        hc = state.get("hand", {}).get("cards", [])
-        if hc:
-            try:
-                client.call("discard", {"cards": list(range(min(len(hc), 5)))})
-                time.sleep(0.2)
-            except APIError:
-                pass
-
-    if joker_keys:
-        for jk in joker_keys:
-            params = {"key": jk} if isinstance(jk, str) else jk
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED joker {params}: {e.message}")
-
-    if card_configs:
-        for cfg in card_configs:
-            params = {"key": cfg["key"]}
-            for k in ("edition", "enhancement", "seal"):
-                if k in cfg:
-                    params[k] = cfg[k]
-            try:
-                client.call("add", params)
-            except APIError as e:
-                print(f"  FAILED card {cfg['key']}: {e.message}")
-
-    time.sleep(0.3)
-    return client.call("gamestate")
+from harness import wait_for_state, setup_game_full as setup_game
 
 
 def dump_jokers(jokers):
@@ -369,6 +302,12 @@ def main():
         if r.get("bot_xmult") != r.get("expected_xmult"):
             xm_note = f" (bot=x{r['bot_xmult']}, expected=x{r['expected_xmult']})"
         print(f"  [{status:8s}] {r['label']:45s} est={r['est']:6d} actual={r['actual']:6d} diff={r['diff']:+d}{xm_note}")
+
+    mismatches = [r for r in results if r and r["diff"] != 0]
+    if mismatches:
+        print(f"\nFAILED: {len(mismatches)} mismatch(es)")
+        sys.exit(1)
+    print("\nPASSED: all scores matched")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_window_pareidolia.py
+++ b/tests/integration/test_window_pareidolia.py
@@ -28,6 +28,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
 _venv_sp = os.path.join(os.path.dirname(__file__), "..", "..", ".venv", "Lib", "site-packages")
 if os.path.isdir(_venv_sp) and _venv_sp not in sys.path:
     sys.path.insert(0, os.path.abspath(_venv_sp))
@@ -40,6 +41,8 @@ from balatro_bot.cards import card_chip_value, _modifier, is_debuffed, card_rank
 from balatro_bot.joker_effects.parsers import parse_effect_value, _ability, _ab_xmult
 from balatro_bot.constants import FACE_RANKS
 
+from harness import wait_for_state
+
 # Lazy-imported: harness eagerly validates config paths at import time.
 # from harness import TEST_PORT, ensure_server, stop_server
 
@@ -47,28 +50,6 @@ from balatro_bot.constants import FACE_RANKS
 # =========================================================================
 # Helpers
 # =========================================================================
-
-def wait_for_state(client, target_states, max_tries=30):
-    state = {}
-    for _ in range(max_tries):
-        state = client.call("gamestate")
-        gs = state.get("state", "")
-        if gs in target_states:
-            return state
-        if gs == "BLIND_SELECT":
-            client.call("select")
-            time.sleep(0.3)
-            continue
-        if gs == "SHOP":
-            client.call("next_round")
-            time.sleep(0.3)
-            continue
-        if gs in ("HAND_PLAYED", "DRAW_TO_HAND", "NEW_ROUND", "ROUND_EVAL"):
-            time.sleep(0.3)
-            continue
-        time.sleep(0.3)
-    raise TimeoutError(f"Never reached {target_states}, stuck in {state.get('state')}")
-
 
 def get_current_blind(state):
     for b in state.get("blinds", {}).values():
@@ -660,8 +641,7 @@ def main():
         if server_proc:
             _stop(server_proc)
 
-    if mismatches > 0:
-        sys.exit(1)
+    assert mismatches == 0, f"{mismatches} scoring mismatch(es) — see SUMMARY above"
 
 
 if __name__ == "__main__":

--- a/tests/test_batch069_fixes.py
+++ b/tests/test_batch069_fixes.py
@@ -8,6 +8,7 @@ Fix 5: Luchador sell clears boss restrictions (context-level)
 """
 
 import math
+from dataclasses import replace as dc_replace
 
 from balatro_bot.domain.scoring.classify import (
     classify_hand,
@@ -201,8 +202,9 @@ class TestFlowerPotDebuffedWild:
             card("T", "H"),   # Heart
         ]
         # Make J♥ a debuffed WILD — should NOT fill the missing Spade
-        cards[3]["modifier"]["enhancement"] = "WILD"
-        cards[3]["state"] = {"debuff": True}
+        cards[3] = dc_replace(cards[3],
+                              modifier=dc_replace(cards[3].modifier, enhancement="WILD"),
+                              state=dc_replace(cards[3].state, debuff=True))
 
         _, _, total_with = score_hand("Straight", cards, jokers=[self._flower_pot()])
         _, _, total_without = score_hand("Straight", cards)
@@ -232,7 +234,7 @@ class TestFlowerPotDebuffedWild:
             card("J", "S"),   # natural Spade
             card("T", "H"),
         ]
-        cards[3]["state"] = {"debuff": True}
+        cards[3] = dc_replace(cards[3], state=dc_replace(cards[3].state, debuff=True))
         _, _, total_with = score_hand("Straight", cards, jokers=[self._flower_pot()])
         _, _, total_without = score_hand("Straight", cards)
         assert total_with > total_without, \

--- a/tests/test_card_model.py
+++ b/tests/test_card_model.py
@@ -1,0 +1,95 @@
+"""Tests for the Card typed model and card_from_dict factory."""
+
+from balatro_bot.domain.models.card import (
+    Card, CardModifier, CardState, CardValue, card_from_dict,
+)
+
+
+def test_card_from_dict_full():
+    d = {
+        "id": 42,
+        "key": "H_K",
+        "set": "DEFAULT",
+        "label": "King of Hearts",
+        "value": {"rank": "K", "suit": "H", "perma_bonus": 5},
+        "modifier": {
+            "enhancement": "GLASS",
+            "edition": "POLYCHROME",
+            "seal": "RED",
+            "edition_chips": 0,
+            "edition_mult": 0,
+            "edition_x_mult": 1.5,
+            "enhancement_x_mult": 2.0,
+        },
+        "state": {"debuff": True},
+        "cost": {"buy": 3, "sell": 1},
+    }
+    c = card_from_dict(d)
+    assert c.id == 42
+    assert c.key == "H_K"
+    assert c.set_ == "DEFAULT"
+    assert c.label == "King of Hearts"
+    assert c.value.rank == "K"
+    assert c.value.suit == "H"
+    assert c.value.perma_bonus == 5
+    assert c.modifier.enhancement == "GLASS"
+    assert c.modifier.edition == "POLYCHROME"
+    assert c.modifier.seal == "RED"
+    assert c.modifier.edition_x_mult == 1.5
+    assert c.modifier.enhancement_x_mult == 2.0
+    assert c.state.debuff is True
+    assert c.cost == {"buy": 3, "sell": 1}
+
+
+def test_card_from_dict_minimal():
+    d = {"key": "S_A"}
+    c = card_from_dict(d)
+    assert c.key == "S_A"
+    assert c.id == 0
+    assert c.value.rank is None
+    assert c.modifier.enhancement is None
+    assert c.state.debuff is False
+
+
+def test_card_from_dict_empty_list_quirk():
+    """The balatrobot API returns [] instead of {} for empty nested objects."""
+    d = {
+        "key": "H_3",
+        "value": {"rank": "3", "suit": "H"},
+        "modifier": [],
+        "state": [],
+    }
+    c = card_from_dict(d)
+    assert c.modifier.enhancement is None
+    assert c.state.debuff is False
+    assert c.value.rank == "3"
+
+
+def test_card_from_dict_perma_bonus_none():
+    """perma_bonus can be None in the API."""
+    d = {"key": "H_5", "value": {"rank": "5", "suit": "H", "perma_bonus": None}}
+    c = card_from_dict(d)
+    assert c.value.perma_bonus == 0
+
+
+def test_card_frozen():
+    c = card_from_dict({"key": "H_A", "value": {"rank": "A", "suit": "H"}})
+    try:
+        c.key = "changed"
+        assert False, "Should have raised FrozenInstanceError"
+    except AttributeError:
+        pass
+
+
+def test_card_replace():
+    """dataclasses.replace works for before-phase mutation pattern."""
+    from dataclasses import replace
+    c = card_from_dict({
+        "key": "H_K",
+        "value": {"rank": "K", "suit": "H"},
+        "modifier": {"enhancement": "BONUS"},
+    })
+    c2 = replace(c, modifier=replace(c.modifier, enhancement="GOLD"))
+    assert c.modifier.enhancement == "BONUS"
+    assert c2.modifier.enhancement == "GOLD"
+    assert c is not c2

--- a/tests/test_discard_ev.py
+++ b/tests/test_discard_ev.py
@@ -58,7 +58,8 @@ def _ctx_for(hand, jokers_list=None, deck=None, discards_left=3):
     jokers_list = jokers_list or []
     if deck is None:
         # Exclude hand cards from deck to match real game state
-        hand_keys = {(c["value"]["rank"], c["value"]["suit"]) for c in hand}
+        from balatro_bot.domain.models.card import Card
+        hand_keys = {(c.value.rank, c.value.suit) if isinstance(c, Card) else (c["value"]["rank"], c["value"]["suit"]) for c in hand}
         deck = _make_deck(exclude=hand_keys)
     return RoundContext(
         blind_score=5000, blind_name="Small Blind", chips_scored=0,

--- a/tests/test_joker_valuation.py
+++ b/tests/test_joker_valuation.py
@@ -26,25 +26,25 @@ class TestSyntheticHand:
         assert len(scoring) == 2
         assert len(played) == 5
         # Both scoring cards should have the same rank
-        assert scoring[0]["value"]["rank"] == scoring[1]["value"]["rank"]
+        assert scoring[0].value.rank == scoring[1].value.rank
 
     def test_flush_produces_flush(self):
         scoring, played = _synthetic_hand("Flush")
         assert len(scoring) == 5
-        suits = {c["value"]["suit"] for c in scoring}
+        suits = {c.value.suit for c in scoring}
         assert len(suits) == 1
 
     def test_straight_produces_straight(self):
         scoring, played = _synthetic_hand("Straight")
         assert len(scoring) == 5
-        ranks = [c["value"]["rank"] for c in scoring]
+        ranks = [c.value.rank for c in scoring]
         assert len(set(ranks)) == 5  # all different ranks
 
     def test_three_of_a_kind(self):
         scoring, played = _synthetic_hand("Three of a Kind")
         assert len(scoring) == 3
         assert len(played) == 5
-        ranks = [c["value"]["rank"] for c in scoring]
+        ranks = [c.value.rank for c in scoring]
         assert len(set(ranks)) == 1
 
     def test_full_house(self):
@@ -56,7 +56,7 @@ class TestSyntheticHand:
         scoring, played = _synthetic_hand("Four of a Kind")
         assert len(scoring) == 4
         assert len(played) == 5
-        ranks = [c["value"]["rank"] for c in scoring]
+        ranks = [c.value.rank for c in scoring]
         assert len(set(ranks)) == 1
 
     def test_high_card(self):
@@ -78,7 +78,7 @@ class TestSyntheticHand:
             active_archetypes=[],
         )
         scoring, played = _synthetic_hand("Flush", strategy=strat)
-        suits = {c["value"]["suit"] for c in scoring}
+        suits = {c.value.suit for c in scoring}
         assert "S" in suits
 
 

--- a/tests/test_play_order.py
+++ b/tests/test_play_order.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace as dc_replace
+
 from balatro_bot.rules._helpers import _sort_play_order, _pad_with_junk
 from tests.conftest import card, joker
 
@@ -91,8 +93,7 @@ def test_hanging_chad_glass_xmult_beats_additive():
 
 def test_hanging_chad_debuffed_card_never_first():
     """Debuffed card should never be placed first."""
-    debuffed = card("A", "S")
-    debuffed["state"]["debuff"] = True
+    debuffed = dc_replace(card("A", "S"), state=dc_replace(card("A", "S").state, debuff=True))
     hand = [
         debuffed,         # 0: debuffed
         card("2", "H"),   # 1: low but not debuffed

--- a/tests/test_playing_policy.py
+++ b/tests/test_playing_policy.py
@@ -5,7 +5,7 @@ from balatro_bot.context import RoundContext
 from balatro_bot.domain.policy.playing import choose_sell_luchador, choose_verdant_leaf_unlock
 from balatro_bot.rules.playing import SellLuchador, VerdantLeafUnlock
 from balatro_bot.strategy import compute_strategy
-from tests.conftest import card, joker
+from tests.conftest import card, debuffed_card, joker
 
 
 def _ctx(
@@ -46,8 +46,7 @@ def _ctx(
 
 
 def test_choose_verdant_leaf_unlock_sells_cheapest_non_protected() -> None:
-    debuffed = card("A", "H")
-    debuffed["state"]["debuff"] = True
+    debuffed = debuffed_card("A", "H")
     jokers = [
         {"key": "j_ride_the_bus", "label": "Ride the Bus", "cost": {"sell": 1}},
         {"key": "j_joker", "label": "Joker", "cost": {"sell": 3}},
@@ -66,8 +65,7 @@ def test_choose_verdant_leaf_unlock_sells_cheapest_non_protected() -> None:
 
 
 def test_verdant_leaf_rule_delegates_to_policy() -> None:
-    debuffed = card("A", "H")
-    debuffed["state"]["debuff"] = True
+    debuffed = debuffed_card("A", "H")
     state = {
         "hand": {"cards": [debuffed]},
         "jokers": {"cards": [{"key": "j_joker", "label": "Joker", "cost": {"sell": 3}}], "limit": 5},

--- a/tests/test_scoring_accuracy.py
+++ b/tests/test_scoring_accuracy.py
@@ -6,7 +6,8 @@ import math
 from balatro_bot.domain.scoring.estimate import score_hand, score_hand_detailed
 from balatro_bot.domain.scoring.base import arm_reduce_hand_levels, flint_halve_hand_levels
 from balatro_bot.cards import card_chip_value
-from tests.conftest import card, wild_card, stone_card, joker
+from dataclasses import replace as dc_replace
+from tests.conftest import card, wild_card, stone_card, card_with_perma, debuffed_card, joker
 
 
 def _joker_with_ability(key: str, ability: dict, **extra) -> dict:
@@ -340,14 +341,12 @@ class TestStoneCardPermaBonus:
 
     def test_stone_with_perma_bonus(self):
         """Stone card with perma_bonus (e.g. from Hiker) adds to 50 base."""
-        sc = stone_card()
-        sc["value"]["perma_bonus"] = 25
+        sc = dc_replace(stone_card(), value=dc_replace(stone_card().value, perma_bonus=25))
         assert card_chip_value(sc) == 75
 
     def test_stone_perma_bonus_zero(self):
         """Stone card with perma_bonus=0 still gives 50."""
         sc = stone_card()
-        sc["value"]["perma_bonus"] = 0
         assert card_chip_value(sc) == 50
 
 
@@ -365,11 +364,9 @@ class TestFlowerPotDebuffed:
             card("A", "H"),
             card("K", "D"),
             card("Q", "C"),
-            card("J", "S"),
+            debuffed_card("J", "S"),
             card("T", "H"),
         ]
-        # Debuff the Spade card — it should still provide its suit
-        cards[3]["state"] = {"debuff": True}
         _, _, total_with = score_hand("Straight", cards, jokers=[self._flower_pot_joker()])
         _, _, total_without = score_hand("Straight", cards)
         # All 4 suits present (debuffed J♠ still contributes Spade)
@@ -631,8 +628,7 @@ class TestRaisedFistDebuffed:
     def test_lowest_debuffed_adds_zero(self):
         """Lowest held card (4♣) debuffed by boss → 0 mult from Raised Fist."""
         played = [card("5", "H"), card("5", "D")]
-        held = [card("A", "D"), card("Q", "D"), card("4", "C")]
-        held[2]["state"] = {"debuff": True}
+        held = [card("A", "D"), card("Q", "D"), debuffed_card("4", "C")]
         result = score_hand_detailed(
             "Pair", played, hand_levels=self._HL,
             jokers=[self._raised_fist_joker()],
@@ -644,8 +640,7 @@ class TestRaisedFistDebuffed:
     def test_non_lowest_debuffed_still_adds(self):
         """Higher card (K♣) debuffed, lowest (4♥) fine → adds 2×4 = 8."""
         played = [card("5", "H"), card("5", "D")]
-        held = [card("K", "C"), card("Q", "D"), card("4", "H")]
-        held[0]["state"] = {"debuff": True}
+        held = [debuffed_card("K", "C"), card("Q", "D"), card("4", "H")]
         result = score_hand_detailed(
             "Pair", played, hand_levels=self._HL,
             jokers=[self._raised_fist_joker()],
@@ -657,9 +652,7 @@ class TestRaisedFistDebuffed:
     def test_all_held_debuffed_adds_zero(self):
         """All held cards debuffed → 0 mult from Raised Fist."""
         played = [card("5", "H"), card("5", "D")]
-        held = [card("A", "C"), card("Q", "C"), card("4", "C")]
-        for c in held:
-            c["state"] = {"debuff": True}
+        held = [debuffed_card("A", "C"), debuffed_card("Q", "C"), debuffed_card("4", "C")]
         result = score_hand_detailed(
             "Pair", played, hand_levels=self._HL,
             jokers=[self._raised_fist_joker()],

--- a/tests/test_scoring_accuracy.py
+++ b/tests/test_scoring_accuracy.py
@@ -394,6 +394,217 @@ class TestFlowerPotDebuffed:
 
 
 # ---------------------------------------------------------------------------
+# Vampire + Flower Pot: enhancement stripping propagation (issue #16)
+# ---------------------------------------------------------------------------
+
+class TestVampireFlowerPot:
+    """Vampire strips enhancements in _apply_before_phase() which runs in the
+    game's 'before' context (card.lua:3805). Flower Pot evaluates in the
+    'joker_main' context (card.lua:4137). Since 'before' completes entirely
+    before 'joker_main' starts, Vampire ALWAYS strips before Flower Pot
+    evaluates — regardless of joker slot order. Regression test for issue #16."""
+
+    def _vampire_joker(self, xmult: float = 1.0):
+        return _joker_with_ability("j_vampire", {"extra": 0.1, "Xmult": xmult})
+
+    def _flower_pot_joker(self):
+        return _joker_with_ability("j_flower_pot", {"extra": 3.0})
+
+    def _assert_flower_pot_does_not_fire(self, cards, jokers):
+        """Flower Pot should NOT fire after Vampire strips the only WILD."""
+        _, _, total_with_both = score_hand("Straight", cards, jokers=jokers)
+        _, _, total_vampire_only = score_hand("Straight", cards, jokers=[self._vampire_joker()])
+        if total_vampire_only > 0:
+            ratio = total_with_both / total_vampire_only
+            assert ratio < 2.0, (
+                f"Flower Pot should NOT fire after Vampire strips WILD "
+                f"(ratio={ratio:.2f}, expected ~1.0)"
+            )
+
+    def test_vampire_strips_wild_before_flower_pot(self):
+        """Vampire strips WILD in the 'before' phase. Flower Pot then sees
+        only 3 natural suits (H, D, C) in 'joker_main' and does NOT fire."""
+        cards = [
+            card("A", "H"),
+            card("K", "D"),
+            card("Q", "C"),
+            card("J", "C"),
+            wild_card("T", "H"),  # WILD provides 4th suit — but Vampire strips it
+        ]
+        # Vampire left of Flower Pot
+        self._assert_flower_pot_does_not_fire(
+            cards, [self._vampire_joker(), self._flower_pot_joker()])
+
+    def test_vampire_right_of_flower_pot_still_strips(self):
+        """Vampire fires in 'before' phase, Flower Pot in 'joker_main'.
+        Even with Flower Pot LEFT of Vampire, Vampire still strips first."""
+        cards = [
+            card("A", "H"),
+            card("K", "D"),
+            card("Q", "C"),
+            card("J", "C"),
+            wild_card("T", "H"),
+        ]
+        # Flower Pot left of Vampire — should NOT matter
+        self._assert_flower_pot_does_not_fire(
+            cards, [self._flower_pot_joker(), self._vampire_joker()])
+
+    def test_vampire_strips_wild_4_natural_suits_flower_pot_still_fires(self):
+        """If all 4 natural suits are present even after WILD is stripped,
+        Flower Pot should still fire."""
+        cards = [
+            card("A", "H"),
+            card("K", "D"),
+            card("Q", "C"),
+            card("J", "S"),
+            wild_card("T", "H"),  # WILD stripped, but 4 natural suits already present
+        ]
+        jokers = [self._vampire_joker(), self._flower_pot_joker()]
+        _, _, total_with_both = score_hand("Straight", cards, jokers=jokers)
+        _, _, total_vampire_only = score_hand("Straight", cards, jokers=[self._vampire_joker()])
+
+        # 4 natural suits (H, D, C, S) present after stripping — Flower Pot fires
+        if total_vampire_only > 0:
+            ratio = total_with_both / total_vampire_only
+            assert ratio > 2.5, (
+                f"Flower Pot should fire with 4 natural suits post-strip "
+                f"(ratio={ratio:.2f}, expected ~3.0)"
+            )
+
+    def test_no_vampire_wild_still_counts_for_flower_pot(self):
+        """Without Vampire, WILD should still provide suit coverage for Flower Pot."""
+        cards = [
+            card("A", "H"),
+            card("K", "D"),
+            card("Q", "C"),
+            card("J", "C"),
+            wild_card("T", "H"),
+        ]
+        jokers = [self._flower_pot_joker()]
+        _, _, total_with = score_hand("Straight", cards, jokers=jokers)
+        _, _, total_without = score_hand("Straight", cards)
+
+        if total_without > 0:
+            ratio = total_with / total_without
+            assert ratio > 2.5, (
+                f"Without Vampire, WILD should let Flower Pot fire "
+                f"(ratio={ratio:.2f}, expected ~3.0)"
+            )
+
+    def test_vampire_strips_mult_enhancement_flower_pot_unaffected(self):
+        """Vampire strips a MULT enhancement (not WILD). Flower Pot should
+        evaluate suits based on natural suits only — no change either way."""
+        cards = [
+            card("A", "H"),
+            card("K", "D"),
+            card("Q", "C"),
+            card("J", "S"),
+            card("T", "H", enhancement="MULT"),
+        ]
+        jokers = [self._vampire_joker(), self._flower_pot_joker()]
+        _, _, total_both = score_hand("Straight", cards, jokers=jokers)
+        _, _, total_fp_only = score_hand("Straight", cards, jokers=[self._flower_pot_joker()])
+
+        # 4 natural suits present regardless of MULT stripping — Flower Pot fires in both
+        assert total_both > 0
+        assert total_fp_only > 0
+
+
+# ---------------------------------------------------------------------------
+# Midas Mask + Vampire: before-phase ordering (card.lua:3783, 3805)
+# ---------------------------------------------------------------------------
+
+class TestMidasVampireOrder:
+    """Midas Mask and Vampire both fire in context.before (state_events.lua:637).
+    Within that phase, jokers iterate left-to-right. Their relative order
+    determines whether Midas-set GOLD gets stripped by Vampire or persists."""
+
+    def _vampire_joker(self, xmult: float = 1.0):
+        return _joker_with_ability("j_vampire", {"extra": 0.1, "Xmult": xmult})
+
+    def _midas_joker(self):
+        return _joker_with_ability("j_midas_mask", {})
+
+    def test_midas_left_vampire_right_strips_gold(self):
+        """Midas (left) sets face cards to GOLD, then Vampire (right) strips
+        GOLD and gains xmult for those cards."""
+        # K♥ is a face card — Midas will set it to GOLD, then Vampire strips it
+        cards = [card("K", "H"), card("K", "D")]
+        jokers = [self._midas_joker(), self._vampire_joker()]
+        _, _, total = score_hand("Pair", cards, jokers=jokers)
+
+        # Vampire should count the GOLD enhancement that Midas set
+        # Baseline: no jokers
+        _, _, base = score_hand("Pair", cards)
+        # With Vampire stripping 2 GOLD enhancements: xmult = 1.0 + 0.1*2 = 1.2
+        # Cards end up BASE (stripped), so no GOLD $3 bonus from card scoring
+        assert total > base, "Vampire should apply xmult from Midas-set GOLD cards"
+
+    def test_vampire_left_midas_right_keeps_gold(self):
+        """Vampire (left) strips existing enhancements first, then Midas (right)
+        sets face cards to GOLD. Face cards end up GOLD for card scoring."""
+        # K♥ has MULT enhancement — Vampire strips it, then Midas sets GOLD
+        cards = [card("K", "H", enhancement="MULT"), card("K", "D")]
+        jokers = [self._vampire_joker(), self._midas_joker()]
+        _, _, total_vm = score_hand("Pair", cards, jokers=jokers)
+
+        # Same cards but Midas left of Vampire — Midas sets GOLD, Vampire strips it
+        cards2 = [card("K", "H", enhancement="MULT"), card("K", "D")]
+        jokers2 = [self._midas_joker(), self._vampire_joker()]
+        _, _, total_mv = score_hand("Pair", cards2, jokers=jokers2)
+
+        # Vampire-left: strips MULT (1 card), gains x1.1. Midas then sets GOLD.
+        #   Cards score with GOLD enhancement during card scoring.
+        # Midas-left: sets both to GOLD, Vampire strips both GOLD, gains x1.2.
+        #   Cards score without enhancement.
+        # Vampire-left should differ from Midas-left due to ordering
+        assert total_vm != total_mv, (
+            f"Order should matter: Vampire-left={total_vm} vs Midas-left={total_mv}"
+        )
+
+    def test_midas_alone_sets_gold_on_face_cards(self):
+        """Midas alone converts face cards to GOLD enhancement."""
+        cards = [card("K", "H"), card("Q", "D")]
+        jokers = [self._midas_joker()]
+        _, _, total_midas = score_hand("Pair", cards, jokers=jokers)
+
+        # Without Midas, plain face cards
+        _, _, total_base = score_hand("Pair", cards)
+        # GOLD cards give $3 each when scored but no chip/mult bonus
+        # The totals may differ due to GOLD replacing base enhancement
+        assert total_midas > 0
+
+    def test_midas_does_not_affect_non_face_cards(self):
+        """Midas only converts face cards (J, Q, K). Number cards unaffected."""
+        cards = [card("7", "H", enhancement="MULT"), card("7", "D")]
+        jokers = [self._midas_joker()]
+        _, _, total_midas = score_hand("Pair", cards, jokers=jokers)
+
+        # Without Midas — should be the same since 7s aren't face cards
+        _, _, total_base = score_hand("Pair", cards)
+        assert total_midas == total_base, "Midas should not affect non-face cards"
+
+    def test_midas_with_pareidolia_affects_all_cards(self):
+        """With Pareidolia, all cards count as face cards for Midas.
+        A MULT-enhanced number card should lose MULT and become GOLD."""
+        # 7♥ has MULT (+4 mult). Pareidolia makes it a "face card" for Midas.
+        # Midas converts it to GOLD, removing the MULT enhancement.
+        cards = [card("7", "H", enhancement="MULT"), card("7", "D")]
+        pareidolia = _joker_with_ability("j_pareidolia", {})
+        jokers_with = [pareidolia, self._midas_joker()]
+        _, mult_with, _ = score_hand("Pair", cards, jokers=jokers_with)
+
+        jokers_without = [pareidolia]
+        _, mult_without, _ = score_hand("Pair", cards, jokers=jokers_without)
+        # Without Midas, 7♥ has MULT enhancement adding +4 mult
+        # With Midas, 7♥ becomes GOLD (no +4 mult)
+        assert mult_with < mult_without, (
+            f"Pareidolia + Midas should strip MULT enhancement from number card "
+            f"(mult_with={mult_with}, mult_without={mult_without})"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Raised Fist with debuffed held cards
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Typed data models**: Frozen `Card`, `Joker`, and `HandLevel` dataclasses replace raw dict access across the scoring engine, joker effects pipeline, and policy layers. Dict-compatible `.get()` on `HandLevel` for backward compat. Factories (`card_from_dict`, `joker_from_dict`) handle the balatrobot API quirk of `[]` for empty objects.
- **Bot decomposition**: `run_bot()` reduced from 642 to ~205 lines. Logging and formatting extracted to `bot_logging.py` and `bot_format.py`. `GameLoopState` dataclass tracks mutable loop state.
- **Bug fixes**: Vampire+Flower Pot before-phase ordering now matches the game's left-to-right joker iteration (fixes #16). Replaced `id()`-based card identity with `is` checks throughout (fixes #20).
- **Test improvements**: Integration tests now assert on scoring mismatches instead of just printing. Duplicated setup helpers consolidated. New `test_card_model.py` and expanded `test_scoring_accuracy.py` with Vampire/Midas/Flower Pot edge cases.
- **Cleanup pass**: Deduplicated modifier→dict conversion, replaced manual field listing in `_ability()` with `dataclasses.fields()`, removed dead `isinstance` branches in logging code.

62 files changed, ~2200 insertions / ~2200 deletions. 322 unit tests passing.

## Test plan

- [x] `pytest tests/ -v` — 322 passed
- [ ] Run a full bot game (`balatro-bot --port 12346 --start`) to verify no runtime regressions
- [ ] Spot-check integration tests against a live server (`python tests/integration/test_hook_scaling.py --start-server --bucket all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)