### PR TITLE
Deck tracking, discard overhaul, victory cleanup

### DIFF
--- a/src/balatro_bot/bot.py
+++ b/src/balatro_bot/bot.py
@@ -423,6 +423,13 @@ def run_bot(
                         )
                 continue
             except httpx.TimeoutException:
+                if cur_ante >= 8:
+                    log.info(
+                        "Server unresponsive at ante %d — likely post-win; exiting gracefully",
+                        cur_ante,
+                    )
+                    gs.actually_won = True
+                    break
                 log.error("Double timeout — server unresponsive, aborting")
                 raise
         except APIError as e:

--- a/src/balatro_bot/bot.py
+++ b/src/balatro_bot/bot.py
@@ -156,7 +156,7 @@ def find_current_blind(state: dict) -> tuple[str, int | str] | None:
 
 def _check_victory(
     gs: GameLoopState, state: dict,
-    pre_play_chips: int = 0, expected_hand_score: int = 0,
+    pre_play_chips: int = 0,
 ) -> bool:
     """Detect ante 9+ victory. Returns True if newly detected."""
     from balatro_bot.bot_logging import log_blind_result
@@ -167,33 +167,13 @@ def _check_victory(
 
     gs.actually_won = True
 
-    if pre_play_chips or expected_hand_score:
-        # Timeout victory — estimate final chips from pre-play + expected score
-        if gs.current_blind_name:
-            target = gs.current_blind_target if isinstance(gs.current_blind_target, int) else 0
-            final_chips = pre_play_chips + expected_hand_score
-            gs.max_chips_this_blind = max(gs.max_chips_this_blind, final_chips)
-            log.info(
-                "VICTORY at ante %s round %s (seed=%s) — scored %s / needed %s — WON | %d hands, %d discards",
-                ante, state.get("round_num", "?"), state.get("seed", "?"),
-                f"{final_chips:,}", f"{target:,}",
-                gs.total_hands_played - gs.hands_at_blind_start,
-                gs.total_discards_used - gs.discards_at_blind_start,
-            )
-        else:
-            log.info(
-                "VICTORY at ante %s round %s (seed=%s)",
-                ante, state.get("round_num", "?"), state.get("seed", "?"),
-            )
-    else:
-        # Normal victory — log to both loggers
-        log.info(
-            "VICTORY at ante %s round %s (seed=%s) — entering endless mode",
-            ante, state.get("round_num", "?"), state.get("seed", "?"),
-        )
-        _stream_log.info("")
-        _stream_log.info("*** VICTORY! ***")
-        log_blind_result(gs, "WON")
+    log.info(
+        "VICTORY at ante %s round %s (seed=%s) — entering endless mode",
+        ante, state.get("round_num", "?"), state.get("seed", "?"),
+    )
+    _stream_log.info("")
+    _stream_log.info("*** VICTORY! ***")
+    log_blind_result(gs, "WON")
 
     gs.current_blind_name = None
     return True
@@ -352,19 +332,6 @@ def run_bot(
             _scoring_log.info("  PRE_PLAY chips_in_round=%d", pre_play_chips)
             play_snapshot = build_play_snapshot(state, params, action)
 
-        # Capture expected hand score for chip accounting on timeout
-        expected_hand_score = 0
-        if method == "play":
-            m = re.search(r"for (\d+)", getattr(action, "reason", ""))
-            if m:
-                expected_hand_score = int(m.group(1))
-
-        # Shorter timeout on ante 8 plays — the win screen hangs the mod
-        saved_timeout = None
-        if method == "play" and cur_ante == 8:
-            saved_timeout = client.timeout
-            client.timeout = 5.0
-
         try:
             _boss_disabled_before = state.get("_boss_disabled", False)
             state = client.call(method, params)
@@ -405,7 +372,7 @@ def run_bot(
                     break
                 # Victory detection: if ante advanced to 9+ during a play
                 # timeout, the win screen caused the hang — handle it here
-                _check_victory(gs, state, pre_play_chips, expected_hand_score)
+                _check_victory(gs, state, pre_play_chips)
                 # Diagnostic dump on timeout
                 post_state = state.get("state", "?")
                 pack_cards = state.get("pack", {}).get("cards", [])
@@ -423,13 +390,6 @@ def run_bot(
                         )
                 continue
             except httpx.TimeoutException:
-                if cur_ante >= 8:
-                    log.info(
-                        "Server unresponsive at ante %d — likely post-win; exiting gracefully",
-                        cur_ante,
-                    )
-                    gs.actually_won = True
-                    break
                 log.error("Double timeout — server unresponsive, aborting")
                 raise
         except APIError as e:
@@ -461,9 +421,5 @@ def run_bot(
                 state = client.call("gamestate")
                 if _boss_disabled_before:
                     state["_boss_disabled"] = True
-        finally:
-            if saved_timeout is not None:
-                client.timeout = saved_timeout
-
     log_game_over(gs, state)
     return gs.actually_won

--- a/src/balatro_bot/context.py
+++ b/src/balatro_bot/context.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from balatro_bot.domain.models.deck_profile import DeckProfile
 from balatro_bot.domain.scoring.base import arm_reduce_hand_levels, flint_halve_hand_levels
 from balatro_bot.domain.scoring.search import HandCandidate, best_hand
 from balatro_bot.infrastructure.state_adapter import adapt_state
@@ -42,6 +43,7 @@ class RoundContext:
     min_cards: int
     strategy: Strategy
     deck_cards: list[dict]
+    deck_profile: DeckProfile = field(default_factory=DeckProfile)
     mouth_locked_hand: str | None = None
     score_discount: float = 1.0
     forced_card_idx: int | None = None
@@ -159,6 +161,7 @@ class RoundContext:
         ancient_suit = snapshot.round.ancient_suit
         ox_most_played = snapshot.round.most_played_poker_hand if blind_name == "The Ox" and not boss_disabled else None
         strat = compute_strategy(jokers, hand_levels)
+        deck_profile = DeckProfile.from_cards(list(deck_cards) + list(hand_cards))
         # When boss is disabled (Luchador sold), clear blind_name for scoring
         # so boss-specific scoring effects (The Tooth, The Ox, etc.) don't fire.
         effective_blind = "" if boss_disabled else blind_name
@@ -199,4 +202,5 @@ class RoundContext:
             min_cards=min_cards,
             strategy=strat,
             deck_cards=deck_cards,
+            deck_profile=deck_profile,
         )

--- a/src/balatro_bot/domain/models/__init__.py
+++ b/src/balatro_bot/domain/models/__init__.py
@@ -1,3 +1,4 @@
+from balatro_bot.domain.models.deck_profile import DeckProfile
 from balatro_bot.domain.models.snapshot import BlindSnapshot, RoundSnapshot, Snapshot
 
-__all__ = ["BlindSnapshot", "RoundSnapshot", "Snapshot"]
+__all__ = ["BlindSnapshot", "DeckProfile", "RoundSnapshot", "Snapshot"]

--- a/src/balatro_bot/domain/models/deck_profile.py
+++ b/src/balatro_bot/domain/models/deck_profile.py
@@ -106,7 +106,7 @@ class DeckProfile:
                 enh = card.modifier.enhancement
             else:
                 mod = card.get("modifier", {})
-                if isinstance(mod, list):
+                if not isinstance(mod, dict):
                     mod = {}
                 enh = mod.get("enhancement")
 

--- a/src/balatro_bot/domain/models/deck_profile.py
+++ b/src/balatro_bot/domain/models/deck_profile.py
@@ -1,0 +1,137 @@
+"""DeckProfile — centralized deck composition summary.
+
+Computed from the full deck (draw pile + hand) once per game tick.
+Provides enhancement counts, suit/rank distributions, and cross-referenced
+enhancement-by-suit and enhancement-by-rank maps.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from balatro_bot.cards import card_rank, card_suits
+
+if TYPE_CHECKING:
+    from balatro_bot.cards import CardLike
+
+ALL_SUITS = ("H", "D", "C", "S")
+
+
+@dataclass(frozen=True)
+class DeckProfile:
+    total_cards: int = 0
+
+    # Suit distribution (Wild cards counted in all suits)
+    suit_counts: dict[str, int] = field(default_factory=dict)
+
+    # Rank distribution (Stone cards excluded — they have no rank)
+    rank_counts: dict[str, int] = field(default_factory=dict)
+
+    # Enhancement counts by type
+    enhancement_counts: dict[str, int] = field(default_factory=dict)
+
+    # Total cards with any non-BASE enhancement (for Drivers License)
+    enhanced_card_count: int = 0
+
+    # Cross-referenced: suit -> {enhancement -> count}
+    enhancements_by_suit: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    # Cross-referenced: rank -> {enhancement -> count}
+    enhancements_by_rank: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Convenience properties
+    # ------------------------------------------------------------------
+
+    @property
+    def has_drivers_license_threshold(self) -> bool:
+        return self.enhanced_card_count >= 16
+
+    @property
+    def dominant_suit(self) -> str | None:
+        if not self.suit_counts:
+            return None
+        return max(self.suit_counts, key=self.suit_counts.get)  # type: ignore[arg-type]
+
+    def enhancement_suit_concentration(self, enhancement: str) -> str | None:
+        """Which suit has the most cards with *enhancement*?"""
+        best_suit = None
+        best_count = 0
+        for suit, enh_map in self.enhancements_by_suit.items():
+            count = enh_map.get(enhancement, 0)
+            if count > best_count:
+                best_count = count
+                best_suit = suit
+        return best_suit
+
+    def enhancement_rank_concentration(self, enhancement: str) -> str | None:
+        """Which rank has the most cards with *enhancement*?"""
+        best_rank = None
+        best_count = 0
+        for rank, enh_map in self.enhancements_by_rank.items():
+            count = enh_map.get(enhancement, 0)
+            if count > best_count:
+                best_count = count
+                best_rank = rank
+        return best_rank
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def from_cards(cards: list[CardLike]) -> DeckProfile:
+        """Build a DeckProfile in a single pass over *cards*."""
+        suit_counts: dict[str, int] = defaultdict(int)
+        rank_counts: dict[str, int] = defaultdict(int)
+        enhancement_counts: dict[str, int] = defaultdict(int)
+        enh_by_suit: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        enh_by_rank: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        enhanced_total = 0
+
+        for card in cards:
+            # Suits (Wild → all four)
+            for s in card_suits(card):
+                suit_counts[s] += 1
+
+            # Rank (None for Stone cards)
+            rank = card_rank(card)
+            if rank is not None:
+                rank_counts[rank] += 1
+
+            # Enhancement
+            if hasattr(card, "modifier"):
+                enh = card.modifier.enhancement
+            else:
+                mod = card.get("modifier", {})
+                if isinstance(mod, list):
+                    mod = {}
+                enh = mod.get("enhancement")
+
+            if enh and enh != "BASE":
+                enhancement_counts[enh] += 1
+                enhanced_total += 1
+
+                # Cross-reference: enhancement by suit
+                if hasattr(card, "value"):
+                    suit = card.value.suit
+                else:
+                    suit = card.get("value", {}).get("suit")
+                if suit:
+                    enh_by_suit[suit][enh] += 1
+
+                # Cross-reference: enhancement by rank
+                if rank is not None:
+                    enh_by_rank[rank][enh] += 1
+
+        return DeckProfile(
+            total_cards=len(cards),
+            suit_counts=dict(suit_counts),
+            rank_counts=dict(rank_counts),
+            enhancement_counts=dict(enhancement_counts),
+            enhanced_card_count=enhanced_total,
+            enhancements_by_suit={s: dict(m) for s, m in enh_by_suit.items()},
+            enhancements_by_rank={r: dict(m) for r, m in enh_by_rank.items()},
+        )

--- a/src/balatro_bot/domain/policy/discard_policy.py
+++ b/src/balatro_bot/domain/policy/discard_policy.py
@@ -172,8 +172,44 @@ def _chase_ev(candidate: ChaseCandidate, ctx: RoundContext, miss_ev: float) -> f
     return candidate.hit_prob * improved + (1 - candidate.hit_prob) * miss_ev
 
 
+# Minimum EV multiplier a chase must beat play_ev by.
+# Scales with discard scarcity: burning your last discard needs a bigger payoff.
+_BASE_CHASE_MARGIN = 1.2       # chase must be at least 1.2× play_ev
+_SCARCITY_BONUS_PER = 0.15     # +0.15× for each discard already used
+
+_HAND_ABBREV = {
+    "High Card": "HC", "Pair": "Pair", "Two Pair": "TP",
+    "Three of a Kind": "3oK", "Straight": "Str", "Flush": "Flush",
+    "Full House": "FH", "Four of a Kind": "4oK", "Straight Flush": "SF",
+    "Five of a Kind": "5oK", "Flush House": "FlH", "Flush Five": "Fl5",
+}
+
+
+def _chase_margin(ctx: RoundContext) -> float:
+    """Required EV multiplier for a chase to be accepted.
+
+    Base margin of 1.2× increases as discards get scarcer.
+    With 3+ discards left the bar is low; with 1 left it's steep.
+    Hopeless outlook lowers the bar — we're desperate.
+    """
+    if ctx.discards_left >= 3:
+        margin = _BASE_CHASE_MARGIN
+    elif ctx.discards_left == 2:
+        margin = _BASE_CHASE_MARGIN + _SCARCITY_BONUS_PER
+    else:
+        margin = _BASE_CHASE_MARGIN + _SCARCITY_BONUS_PER * 2
+
+    if ctx.round_outlook == "hopeless":
+        margin = max(1.05, margin * 0.7)
+
+    return margin
+
+
 def _best_chase(suggestions: list[ChaseCandidate], ctx: RoundContext, play_ev: float) -> DiscardCards | None:
-    """Find the best chase candidate whose EV exceeds play_ev."""
+    """Find the best chase candidate whose EV exceeds play_ev by the required margin."""
+    margin_req = _chase_margin(ctx)
+    ev_threshold = play_ev * margin_req
+
     # Build miss_ev cache — one sample pass per unique keep set
     miss_ev_cache: dict[tuple[int, ...], float] = {}
     for candidate in suggestions:
@@ -182,55 +218,50 @@ def _best_chase(suggestions: list[ChaseCandidate], ctx: RoundContext, play_ev: f
         key = tuple(sorted(candidate.keep_indices))
         if key not in miss_ev_cache:
             miss_ev_cache[key] = _sample_miss_ev(candidate.keep_indices, ctx)
-            log.info("MC miss_ev for keep=%s: %.0f (play_ev=%.0f)", key, miss_ev_cache[key], play_ev)
+            log.info("MC miss_ev for keep=%s: %.0f (play_ev=%.0f, threshold=%.0f, margin=%.2fx)", key, miss_ev_cache[key], play_ev, ev_threshold, margin_req)
 
-    # Find best chase by EV
+    # Find best chase by EV (must clear the margin threshold)
     best = None
-    best_ev = play_ev
+    best_ev = ev_threshold
 
     for candidate in suggestions:
         if "chase" not in candidate.reason:
             continue
         key = tuple(sorted(candidate.keep_indices))
         ev = _chase_ev(candidate, ctx, miss_ev_cache[key])
+        accepted = ev > best_ev
         log.info(
-            "chase EV: %s %.0f%% -> EV %.0f (miss=%.0f, play=%.0f) %s",
+            "chase EV: %s %.0f%% -> EV %.0f (miss=%.0f, threshold=%.0f) %s",
             candidate.chase_hand, candidate.hit_prob * 100, ev,
-            miss_ev_cache[key], play_ev,
-            "ACCEPT" if ev > best_ev else "reject",
+            miss_ev_cache[key], ev_threshold,
+            "ACCEPT" if accepted else "reject",
         )
-        if ev > best_ev:
+        if accepted:
             best_ev = ev
             best = candidate
 
     # Stream log — consolidated one-liner for all chase evaluations
-    _HAND_ABBREV = {
-        "High Card": "HC", "Pair": "Pair", "Two Pair": "TP",
-        "Three of a Kind": "3oK", "Straight": "Str", "Flush": "Flush",
-        "Full House": "FH", "Four of a Kind": "4oK", "Straight Flush": "SF",
-        "Five of a Kind": "5oK", "Flush House": "FlH", "Flush Five": "Fl5",
-    }
     chase_parts = []
     for candidate in suggestions:
         if "chase" not in candidate.reason:
             continue
         key = tuple(sorted(candidate.keep_indices))
         ev = _chase_ev(candidate, ctx, miss_ev_cache[key])
-        accepted = ev > play_ev
+        accepted = ev > ev_threshold
         abbrev = _HAND_ABBREV.get(candidate.chase_hand, candidate.chase_hand)
         chase_parts.append(
             f"{abbrev} {candidate.hit_prob * 100:.0f}% EV {ev:.0f} {'YES' if accepted else 'no'}"
         )
     if chase_parts:
-        _stream_log.info("Considering chase: %s (play EV %.0f)", " | ".join(chase_parts), play_ev)
+        _stream_log.info("Considering chase: %s (play EV %.0f, need %.1fx)", " | ".join(chase_parts), play_ev, margin_req)
 
     if best is not None:
         margin = best_ev / play_ev if play_ev > 0 else float("inf")
-        log.info("chase ACCEPTED: %s EV %.0f vs play %.0f (%.1fx)", best.chase_hand, best_ev, play_ev, margin)
+        log.info("chase ACCEPTED: %s EV %.0f vs play %.0f (%.1fx, needed %.1fx)", best.chase_hand, best_ev, play_ev, margin, margin_req)
         return DiscardCards(
             best.discard_indices,
             reason=f"{best.reason} [EV {best_ev:.0f} vs play {play_ev:.0f}, {margin:.1f}x]",
         )
     if miss_ev_cache:
-        log.info("all chases rejected (play_ev=%.0f beats all)", play_ev)
+        log.info("all chases rejected (play_ev=%.0f, threshold=%.0f, margin=%.2fx)", play_ev, ev_threshold, margin_req)
     return None

--- a/src/balatro_bot/domain/policy/discard_policy.py
+++ b/src/balatro_bot/domain/policy/discard_policy.py
@@ -32,7 +32,8 @@ KEEP_DISCARDS_JOKERS = {
     "j_ramen",          # -0.01 xmult per card discarded
 }
 
-N_SAMPLES = 30  # Monte Carlo samples per unique keep set
+N_SAMPLES = 30          # Monte Carlo samples per unique keep set
+_RISK_AVERSION = 0.5    # upside discount per unit of miss probability
 
 
 def choose_discard(ctx: RoundContext) -> Action | None:
@@ -151,7 +152,12 @@ def _sample_miss_ev(keep_indices: list[int], ctx: RoundContext) -> float:
 
 
 def _chase_ev(candidate: ChaseCandidate, ctx: RoundContext, miss_ev: float) -> float:
-    """Expected value of taking a chase discard."""
+    """Risk-adjusted expected value of taking a chase discard.
+
+    Discounts the upside by miss probability — low-probability chases
+    need proportionally bigger payoffs to justify the gamble.  A 90% chase
+    keeps ~95% of its upside; a 10% lottery ticket keeps only ~55%.
+    """
     if candidate.chase_hand == "redraw":
         return miss_ev
 
@@ -169,7 +175,9 @@ def _chase_ev(candidate: ChaseCandidate, ctx: RoundContext, miss_ev: float) -> f
         ancient_suit=ctx.ancient_suit,
     )
 
-    return candidate.hit_prob * improved + (1 - candidate.hit_prob) * miss_ev
+    risk_factor = 1.0 - candidate.hit_prob
+    upside_discount = 1.0 - risk_factor * _RISK_AVERSION
+    return candidate.hit_prob * improved * upside_discount + (1 - candidate.hit_prob) * miss_ev
 
 
 # Minimum EV multiplier a chase must beat play_ev by.

--- a/src/balatro_bot/domain/policy/discard_policy.py
+++ b/src/balatro_bot/domain/policy/discard_policy.py
@@ -32,7 +32,7 @@ KEEP_DISCARDS_JOKERS = {
     "j_ramen",          # -0.01 xmult per card discarded
 }
 
-N_SAMPLES = 10  # Monte Carlo samples per unique keep set
+N_SAMPLES = 30  # Monte Carlo samples per unique keep set
 
 
 def choose_discard(ctx: RoundContext) -> Action | None:
@@ -102,6 +102,7 @@ def choose_discard(ctx: RoundContext) -> Action | None:
         chips_remaining=ctx.chips_remaining,
         jokers=ctx.jokers,
         required_hand=ctx.mouth_locked_hand,
+        deck_profile=ctx.deck_profile,
     )
 
     # Try EV-based chase first

--- a/src/balatro_bot/domain/policy/discard_policy.py
+++ b/src/balatro_bot/domain/policy/discard_policy.py
@@ -76,7 +76,7 @@ def choose_discard(ctx: RoundContext) -> Action | None:
         # Desperation cycle: extra cards in hand + hopeless outlook
         extra_count = len(ctx.hand_cards) - 5
         if extra_count > 0 and outlook == "hopeless":
-            extras = cards_not_in(ctx.hand_cards, set(ctx.best.card_indices), rank_affinity=ctx.strategy.rank_affinity_dict(), scoring_suit=ctx.scoring_suit)
+            extras = cards_not_in(ctx.hand_cards, set(ctx.best.card_indices), rank_affinity=ctx.strategy.rank_affinity_dict(), scoring_suit=ctx.scoring_suit, strategy=ctx.strategy)
             to_discard = extras[:min(extra_count, ctx.discards_left, 5)]
             if to_discard:
                 return DiscardCards(

--- a/src/balatro_bot/domain/policy/pack_policy.py
+++ b/src/balatro_bot/domain/policy/pack_policy.py
@@ -17,6 +17,7 @@ from balatro_bot.constants import (
 
 if TYPE_CHECKING:
     from typing import Any
+    from balatro_bot.domain.models.deck_profile import DeckProfile
     from balatro_bot.strategy import Strategy
 
 log = logging.getLogger("balatro_bot")
@@ -141,6 +142,7 @@ def choose_from_buffoon_pack(
     joker_limit: int,
     strat: Strategy,
     always_buy_keys: set[str],
+    deck_profile: DeckProfile | None = None,
 ) -> tuple[int, float, str]:
     """Pick the best joker from a Buffoon pack.
 
@@ -178,7 +180,7 @@ def choose_from_buffoon_pack(
         score = evaluate_joker_value(
             card, owned_jokers=owned_jokers,
             hand_levels=hand_levels, ante=ante, strategy=strat,
-            joker_limit=joker_limit,
+            joker_limit=joker_limit, deck_profile=deck_profile,
         )
         # S-tier jokers get a massive boost
         if key in always_buy_keys:

--- a/src/balatro_bot/domain/policy/play_policy.py
+++ b/src/balatro_bot/domain/policy/play_policy.py
@@ -134,7 +134,7 @@ def choose_best_available(ctx: RoundContext) -> Action | None:
     if ctx.blind_name == "The Needle" and ctx.discards_left > 0:
         if ctx.best:
             keep = set(ctx.best.card_indices)
-            to_discard = cards_not_in(ctx.hand_cards, keep, rank_affinity=ctx.strategy.rank_affinity_dict(), scoring_suit=ctx.scoring_suit)[:min(5, ctx.discards_left)]
+            to_discard = cards_not_in(ctx.hand_cards, keep, rank_affinity=ctx.strategy.rank_affinity_dict(), scoring_suit=ctx.scoring_suit, strategy=ctx.strategy)[:min(5, ctx.discards_left)]
             if to_discard:
                 return DiscardCards(to_discard, reason="Needle: use all discards to find winning hand")
         return None
@@ -144,7 +144,7 @@ def choose_best_available(ctx: RoundContext) -> Action | None:
     if (ctx.best and ctx.best.total < ctx.chips_remaining
             and ctx.discards_left > 0 and len(ctx.best.card_indices) < 5):
         keep = set(ctx.best.card_indices)
-        to_discard = cards_not_in(ctx.hand_cards, keep, rank_affinity=ctx.strategy.rank_affinity_dict(), scoring_suit=ctx.scoring_suit)[:min(5, ctx.discards_left)]
+        to_discard = cards_not_in(ctx.hand_cards, keep, rank_affinity=ctx.strategy.rank_affinity_dict(), scoring_suit=ctx.scoring_suit, strategy=ctx.strategy)[:min(5, ctx.discards_left)]
         if to_discard:
             return DiscardCards(to_discard, reason="last resort discard (hand too weak, searching for better)")
 

--- a/src/balatro_bot/domain/policy/play_policy.py
+++ b/src/balatro_bot/domain/policy/play_policy.py
@@ -410,10 +410,10 @@ def _milk_play_action(ctx: RoundContext, joker_keys: set,
                     deck_cards=ctx.deck_cards,
                 )
                 if chases:
-                    indices, reason = chases[0]
+                    best = chases[0]
                     return DiscardCards(
-                        indices,
-                        reason=f"milk: chase {ht} for {jname} ({reason})",
+                        best.discard_indices,
+                        reason=f"milk: chase {ht} for {jname} ({best.reason})",
                     )
 
     # --- Category 3: Generic triggers ---

--- a/src/balatro_bot/domain/policy/play_policy.py
+++ b/src/balatro_bot/domain/policy/play_policy.py
@@ -42,7 +42,7 @@ def choose_winning_play(ctx: RoundContext) -> Action | None:
         return None
     effective_score = ctx.best.total * ctx.score_discount
     if effective_score >= ctx.chips_remaining:
-        indices = _pad_with_junk(ctx.best.card_indices, ctx.hand_cards, ctx.jokers, ctx.best.hand_name)
+        indices = _pad_with_junk(ctx.best.card_indices, ctx.hand_cards, ctx.jokers, ctx.best.hand_name, strategy=ctx.strategy, scoring_suit=ctx.scoring_suit)
         indices = _sort_play_order(indices, ctx.hand_cards, ctx.jokers, ctx.strategy)
         return PlayCards(
             indices,
@@ -115,7 +115,7 @@ def choose_high_value_play(ctx: RoundContext) -> Action | None:
         )
         return None
 
-    indices = _pad_with_junk(ctx.best.card_indices, ctx.hand_cards, ctx.jokers, ctx.best.hand_name)
+    indices = _pad_with_junk(ctx.best.card_indices, ctx.hand_cards, ctx.jokers, ctx.best.hand_name, strategy=ctx.strategy, scoring_suit=ctx.scoring_suit)
     indices = _sort_play_order(indices, ctx.hand_cards, ctx.jokers, ctx.strategy)
     return PlayCards(
         indices,
@@ -149,7 +149,7 @@ def choose_best_available(ctx: RoundContext) -> Action | None:
             return DiscardCards(to_discard, reason="last resort discard (hand too weak, searching for better)")
 
     if ctx.best:
-        indices = _pad_with_junk(ctx.best.card_indices, ctx.hand_cards, ctx.jokers, ctx.best.hand_name)
+        indices = _pad_with_junk(ctx.best.card_indices, ctx.hand_cards, ctx.jokers, ctx.best.hand_name, strategy=ctx.strategy, scoring_suit=ctx.scoring_suit)
         indices = _sort_play_order(indices, ctx.hand_cards, ctx.jokers, ctx.strategy)
         return PlayCards(
             indices,
@@ -166,7 +166,7 @@ def choose_best_available(ctx: RoundContext) -> Action | None:
             hands_left=ctx.hands_left,
         )
         if unconstrained:
-            indices = _pad_with_junk(unconstrained.card_indices, ctx.hand_cards, ctx.jokers, unconstrained.hand_name)
+            indices = _pad_with_junk(unconstrained.card_indices, ctx.hand_cards, ctx.jokers, unconstrained.hand_name, strategy=ctx.strategy, scoring_suit=ctx.scoring_suit)
             indices = _sort_play_order(indices, ctx.hand_cards, ctx.jokers, ctx.strategy)
             return PlayCards(
                 indices,

--- a/src/balatro_bot/domain/policy/shop.py
+++ b/src/balatro_bot/domain/policy/shop.py
@@ -279,7 +279,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
     sell_value = weakest_joker.get("cost", {}).get("sell", 0)
     # Use post-sell interest as baseline — BuyJokersInShop will see
     # post-sell money, so the sell-side guard must match that bracket.
-    current_interest = min((money + sell_value) // 5, 5)
+    current_interest = _interest_after(money + sell_value, 0)
 
     best_sell_target = None
     best_shop_value = -1.0
@@ -301,7 +301,7 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
             continue
 
         if ante < _INTEREST_ANTE_CUTOFF and money_after_sell < INTEREST_CAP:
-            interest_after_buy = min((money_after_sell - cost) // 5, 5)
+            interest_after_buy = _interest_after(money_after_sell, cost)
             if interest_after_buy < current_interest:
                 continue
 
@@ -613,9 +613,9 @@ def choose_buy_consumable_in_shop(state: dict[str, Any]) -> Action | None:
             passed_on.append(f"{label}(${cost}, can't afford)")
             continue
 
-        current_interest = min(money // 5, 5)
+        current_interest = _interest_after(money, 0)
         if money < INTEREST_CAP:
-            interest_after = min((money - cost) // 5, 5)
+            interest_after = _interest_after(money, cost)
             if interest_after < current_interest and cost > 3:
                 passed_on.append(f"{label}(${cost}, saving for interest)")
                 continue

--- a/src/balatro_bot/domain/policy/shop.py
+++ b/src/balatro_bot/domain/policy/shop.py
@@ -14,6 +14,7 @@ from balatro_bot.constants import (
     SCALING_JOKERS, SCALING_XMULT, SPECTRAL_TARGETING, TARGETING_TAROTS,
 )
 from balatro_bot.cards import joker_key
+from balatro_bot.domain.models.deck_profile import DeckProfile
 from balatro_bot.joker_effects import JOKER_EFFECTS, _noop, parse_effect_value
 from balatro_bot.domain.policy.shop_valuation import evaluate_joker_value
 from balatro_bot.rules._helpers import evaluate_hex
@@ -23,6 +24,20 @@ if TYPE_CHECKING:
     from typing import Any
 
 log = logging.getLogger("balatro_bot")
+
+
+def _get_deck_profile(state: dict[str, Any]) -> DeckProfile:
+    """Get or build+cache a DeckProfile from the raw state dict."""
+    cached = state.get("_deck_profile")
+    if cached is not None:
+        return cached
+    from balatro_bot.domain.models.card import card_from_dict
+    deck_cards = [card_from_dict(c) for c in state.get("cards", {}).get("cards", [])]
+    hand_cards = [card_from_dict(c) for c in state.get("hand", {}).get("cards", [])]
+    profile = DeckProfile.from_cards(deck_cards + hand_cards)
+    state["_deck_profile"] = profile
+    return profile
+
 
 # ── Tuning constants ─────────────────────────────────────────────────
 
@@ -119,6 +134,19 @@ def _pack_priority(label: str) -> int | None:
     return None
 
 
+def _riff_raff_reserved_slots(owned_cards: list[dict], joker_limit: int) -> int:
+    """Return how many slots Riff-Raff reserves for spawns (0-2).
+
+    Riff-Raff spawns 2 Common jokers on blind select IF there are empty slots.
+    Returns 0 if Riff-Raff is not owned or slots are already full.
+    """
+    has_riff_raff = any(joker_key(j) == "j_riff_raff" for j in owned_cards)
+    if not has_riff_raff:
+        return 0
+    free_slots = max(0, joker_limit - len(owned_cards))
+    return min(2, free_slots)
+
+
 # ── Policy functions ─────────────────────────────────────────────────
 
 def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
@@ -148,8 +176,44 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
                     i, reason=f"sell decayed Ramen (X{current_xmult:.2f}, reducing scores)"
                 )
 
+    # Proactive sell: dead Riff-Raff when all joker slots are full
+    joker_count = joker_info.get("count", 0)
+    joker_limit = joker_info.get("limit", 5)
+    for i, j in enumerate(owned):
+        if joker_key(j) == "j_riff_raff" and joker_count >= joker_limit:
+            return SellJoker(
+                i, reason="sell dead Riff-Raff (all joker slots full, spawns can't trigger)"
+            )
+
+    # Proactive sell: weak Common jokers when Riff-Raff is owned and slots tight
+    has_riff_raff = any(joker_key(j) == "j_riff_raff" for j in owned)
+    if has_riff_raff and joker_count >= joker_limit - 1:
+        hand_levels = state.get("hands", {})
+        ante = state.get("ante_num", 1)
+        strat = compute_strategy(owned, hand_levels)
+        _rr_protected = {"j_madness", "j_ceremonial", "j_riff_raff"} | SCALING_XMULT
+        common_candidates = []
+        for i, j in enumerate(owned):
+            if joker_key(j) in _rr_protected or _is_polychrome(j):
+                continue
+            rarity = j.get("value", {}).get("rarity")
+            if rarity not in (1, "Common"):
+                continue
+            val = evaluate_joker_value(j, owned_jokers=owned,
+                                       hand_levels=hand_levels, ante=ante, strategy=strat,
+                                       deck_profile=_get_deck_profile(state))
+            if val < 1.0:
+                common_candidates.append((i, val, j))
+        if common_candidates:
+            worst_idx, worst_val, worst_j = min(common_candidates, key=lambda x: x[1])
+            return SellJoker(
+                worst_idx,
+                reason=f"sell weak Common {worst_j.get('label', '?')} "
+                       f"(value={worst_val:.1f}, freeing slot for Riff-Raff spawns)",
+            )
+
     # Only consider upgrade-selling when slots are full
-    if joker_info.get("count", 0) < joker_info.get("limit", 5):
+    if joker_count < joker_limit:
         return None
     if not owned:
         return None
@@ -173,6 +237,16 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
     else:
         protected = always_protected | SCALING_JOKERS
 
+    # Baseball Card: protect Uncommon jokers that feed its x1.5 triggers
+    owned_keys = {joker_key(j) for j in owned}
+    if "j_baseball" in owned_keys:
+        uncommon_keys = {
+            joker_key(j) for j in owned
+            if j.get("value", {}).get("rarity") in (2, "Uncommon")
+        }
+        if len(uncommon_keys) >= 2:  # only protect when Baseball has real value
+            protected = protected | uncommon_keys
+
     def _is_stale_scaler(j: dict, cur_ante: int) -> bool:
         key = joker_key(j)
         if key not in SCALING_JOKERS or key in always_protected:
@@ -187,9 +261,11 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
             return True
         return False
 
+    _dp = _get_deck_profile(state)
     owned_values = [
         (i, evaluate_joker_value(j, owned_jokers=owned,
-                                 hand_levels=hand_levels, ante=ante, strategy=strat), j)
+                                 hand_levels=hand_levels, ante=ante, strategy=strat,
+                                 deck_profile=_dp), j)
         for i, j in enumerate(owned)
         if (joker_key(j) not in protected or _is_stale_scaler(j, ante))
         and not _is_polychrome(j)  # never sell Polychrome — ×1.5 every hand
@@ -230,7 +306,8 @@ def choose_sell_weak_joker(state: dict[str, Any]) -> Action | None:
                 continue
 
         shop_value = evaluate_joker_value(card, owned_jokers=owned,
-                                          hand_levels=hand_levels, ante=ante, strategy=strat)
+                                          hand_levels=hand_levels, ante=ante, strategy=strat,
+                                          deck_profile=_dp)
         shop_key = card.get("key", "")
         is_high_tier_xmult = shop_key in HIGH_VALUE_XMULT
 
@@ -423,6 +500,7 @@ def choose_buy_joker_in_shop(state: dict[str, Any]) -> Action | None:
             card, owned_jokers=joker_slots.get("cards", []),
             hand_levels=state.get("hands", {}), ante=ante,
             strategy=strat, joker_limit=jlimit,
+            deck_profile=_get_deck_profile(state),
         )
 
         force_buy = False
@@ -444,6 +522,14 @@ def choose_buy_joker_in_shop(state: dict[str, Any]) -> Action | None:
             if stencil_mult_after <= 2 and value < 5.0:
                 passed_on.append(f"{label}(${cost}, Stencil restriction: only ×{stencil_mult_after} left)")
                 continue
+
+        # Riff-Raff slot reservation: penalize buys that eat into spawn slots
+        if not negative and not force_buy:
+            rr_reserved = _riff_raff_reserved_slots(joker_slots.get("cards", []), jlimit)
+            if rr_reserved > 0:
+                free_after_buy = jlimit - joker_count - 1
+                if free_after_buy < rr_reserved:
+                    value *= 0.7
 
         if joker_count == 0:
             value = max(value, 5.0)

--- a/src/balatro_bot/domain/policy/shop_valuation.py
+++ b/src/balatro_bot/domain/policy/shop_valuation.py
@@ -528,8 +528,6 @@ def _deck_composition_adjustment(
     strategy: Strategy | None,
 ) -> float:
     """Adjust base_value based on deck composition."""
-    from balatro_bot.domain.models.deck_profile import DeckProfile  # noqa: F811
-
     # --- Enhancement-count jokers (Steel Joker, Lucky Cat, Glass Joker) ---
     enh_type = _ENHANCEMENT_JOKERS.get(key)
     if enh_type:

--- a/src/balatro_bot/domain/policy/shop_valuation.py
+++ b/src/balatro_bot/domain/policy/shop_valuation.py
@@ -26,7 +26,7 @@ from balatro_bot.strategy import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from balatro_bot.domain.models.deck_profile import DeckProfile
 
 # ---------------------------------------------------------------------------
 # Scoring category metadata (moved from BuyJokersInShop)
@@ -406,6 +406,7 @@ def _synergy_multiplier(
     owned_keys: set[str],
     strategy: Strategy,
     owned_jokers: list[dict],
+    candidate: dict | None = None,
 ) -> float:
     """Unified synergy multiplier replacing _cross_synergy + coherence bonus."""
     mult = 1.0
@@ -425,6 +426,21 @@ def _synergy_multiplier(
     if candidate_key in _COPY_JOKERS:
         if owned_keys & _XMULT_COPY_TARGETS:
             mult *= 1.3
+
+    # --- Baseball Card synergy (rarity-based) ---
+    uncommon_count = sum(
+        1 for j in owned_jokers
+        if j.get("value", {}).get("rarity") in (2, "Uncommon")
+        and joker_key(j) != "j_baseball"
+    )
+    if candidate_key == "j_baseball":
+        # Baseball scales with Uncommon count: more Uncommons = more x1.5 triggers
+        mult *= 1.0 + uncommon_count * 0.3
+    elif "j_baseball" in owned_keys and candidate is not None:
+        # Uncommon candidates get a boost when Baseball is owned
+        cand_rarity = candidate.get("value", {}).get("rarity")
+        if cand_rarity in (2, "Uncommon"):
+            mult *= 1.4
 
     # --- Trigger coherence (hand type overlap) ---
     candidate_hands = set(JOKER_HAND_AFFINITY.get(candidate_key, ([], 0))[0])
@@ -480,6 +496,94 @@ def _context_scale(
 
 
 # ---------------------------------------------------------------------------
+# Deck composition adjustments
+# ---------------------------------------------------------------------------
+
+# Joker key -> enhancement it cares about
+_ENHANCEMENT_JOKERS: dict[str, str] = {
+    "j_steel_joker": "STEEL",
+    "j_lucky_cat": "LUCKY",
+    "j_glass": "GLASS",
+}
+
+# Suit-affinity jokers — key -> suit they care about
+_SUIT_JOKERS: dict[str, str] = {
+    "j_greedy_joker": "D",
+    "j_lusty_joker": "H",
+    "j_wrathful_joker": "S",
+    "j_gluttenous_joker": "C",
+    "j_arrowhead": "S",
+    "j_onyx_agate": "C",
+    "j_bloodstone": "H",
+    "j_rough_gem": "D",
+}
+
+_FACE_RANKS = frozenset({"J", "Q", "K"})
+
+
+def _deck_composition_adjustment(
+    key: str,
+    base_value: float,
+    deck_profile: DeckProfile,
+    strategy: Strategy | None,
+) -> float:
+    """Adjust base_value based on deck composition."""
+    from balatro_bot.domain.models.deck_profile import DeckProfile  # noqa: F811
+
+    # --- Enhancement-count jokers (Steel Joker, Lucky Cat, Glass Joker) ---
+    enh_type = _ENHANCEMENT_JOKERS.get(key)
+    if enh_type:
+        count = deck_profile.enhancement_counts.get(enh_type, 0)
+        if count == 0:
+            # No matching enhanced cards → heavily penalize
+            base_value *= 0.2
+        else:
+            # Each matching card adds value (diminishing)
+            base_value += math.log2(1 + count) * 1.5
+
+            # Suit-concentration synergy: if enhanced cards cluster in a suit
+            # the bot already favors, that's extra valuable
+            if strategy and strategy.preferred_suits:
+                conc_suit = deck_profile.enhancement_suit_concentration(enh_type)
+                if conc_suit:
+                    suit_aff = strategy.suit_affinity(conc_suit)
+                    if suit_aff > 0:
+                        base_value += min(suit_aff * 0.3, 1.5)
+
+            # Lucky Cat + face-card synergy: Lucky cards on face ranks
+            # synergize with face-card jokers
+            if key == "j_lucky_cat":
+                enh_by_rank = deck_profile.enhancements_by_rank
+                face_lucky = sum(
+                    enh_by_rank.get(r, {}).get("LUCKY", 0)
+                    for r in _FACE_RANKS
+                )
+                if face_lucky >= 2 and strategy and strategy.active_archetypes:
+                    if any(a == "face_card" for a, _ in strategy.active_archetypes):
+                        base_value += face_lucky * 0.4
+
+    # --- Drivers License: gate on enhanced card count ---
+    if key == "j_drivers_license":
+        enh_count = deck_profile.enhanced_card_count
+        if enh_count < 12:
+            base_value *= 0.1  # can't realistically activate
+        elif enh_count < 16:
+            base_value *= 0.5  # close but not there yet
+        # >= 16: full value (already activated)
+
+    # --- Suit-affinity jokers: bonus when that suit has enhancements ---
+    suit = _SUIT_JOKERS.get(key)
+    if suit:
+        suit_enhancements = deck_profile.enhancements_by_suit.get(suit, {})
+        enh_total = sum(suit_enhancements.values())
+        if enh_total > 0:
+            # Enhanced cards in the suit retrigger/score extra → suit joker more valuable
+            base_value += min(enh_total * 0.3, 2.0)
+
+    return base_value
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -490,6 +594,7 @@ def evaluate_joker_value(
     ante: int,
     strategy: Strategy | None = None,
     joker_limit: int = 5,
+    deck_profile: DeckProfile | None = None,
 ) -> float:
     """Unified joker valuation. Returns ~0.0 to ~15.0.
 
@@ -516,6 +621,20 @@ def evaluate_joker_value(
         base_value = UTILITY_VALUE.get(key, 0.0)
         base_value += _utility_synergy_bonus(key, owned_keys, strategy)
 
+    # Riff-Raff: dynamic value based on available slots for spawns
+    if key == "j_riff_raff":
+        owned_count = len(owned_jokers)
+        free_slots = max(0, joker_limit - owned_count)
+        if free_slots <= 1:
+            # No room for spawns (Riff-Raff itself takes the last slot)
+            base_value = 0.0
+        elif free_slots == 2:
+            # Room for Riff-Raff + 1 spawn only
+            base_value = 0.5
+        else:
+            # Room for Riff-Raff + 2 spawns — full value
+            base_value = 2.0 if ante <= 3 else 1.0
+
     # For jokers with parsed accumulated values (scaling jokers), take the
     # max of simulation and dynamic power from effect text
     effect_text = candidate.get("value", {}).get("effect", "")
@@ -524,8 +643,12 @@ def evaluate_joker_value(
         dp = _dynamic_power(parsed)
         base_value = max(base_value, dp)
 
+    # Deck composition adjustment — boost/gate jokers based on deck contents
+    if deck_profile is not None:
+        base_value = _deck_composition_adjustment(key, base_value, deck_profile, strategy)
+
     # Layer 2: synergy
-    synergy = _synergy_multiplier(key, owned_keys, strategy, owned_jokers)
+    synergy = _synergy_multiplier(key, owned_keys, strategy, owned_jokers, candidate)
 
     # Layer 3: context
     context = _context_scale(key, owned_jokers, ante)

--- a/src/balatro_bot/domain/scoring/chase.py
+++ b/src/balatro_bot/domain/scoring/chase.py
@@ -1,0 +1,299 @@
+"""Chase strategy generation for the discard system.
+
+Enumerates all viable hand-type transitions from the current hand state,
+builds strategy tuples with keep sets and hit probabilities.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from balatro_bot.domain.models.deck_profile import DeckProfile
+
+from balatro_bot.cards import joker_key
+from balatro_bot.constants import HAND_INFO
+from balatro_bot.domain.scoring.draws import (
+    flush_draw,
+    flush_draw_quality,
+    flush_draw_quality_loose,
+    straight_draw,
+    straight_draw_quality,
+    two_pair_draw_quality,
+    two_pair_draw_quality_tight,
+    three_kind_draw_quality,
+    full_house_draw_quality,
+    full_house_draw_quality_tight,
+    four_kind_draw_quality,
+    pair_draw_quality,
+    straight_flush_draw_quality,
+    flush_house_draw_quality,
+    flush_five_draw_quality,
+    five_kind_draw_quality,
+)
+
+# Strategy tuple: (hand_name, keep_indices, probability, reason)
+StrategyTuple = tuple[str, list[int], float, str]
+
+
+def generate_chases(
+    hand_cards: list[dict],
+    bh,
+    hand_levels: dict[str, dict] | None = None,
+    deck_cards: list[dict] | None = None,
+    jokers: list[dict] | None = None,
+    chips_remaining: int = 0,
+    max_discard: int = 5,
+    rank_affinity: dict[str, float] | None = None,
+    required_hand: str | None = None,
+    deck_profile: DeckProfile | None = None,
+) -> list[StrategyTuple]:
+    """Generate all viable chase strategies from the current hand state.
+
+    Returns a list of (hand_name, keep_indices, probability, reason) tuples.
+    Does NOT score or rank them — that's the caller's job.
+    """
+    joker_keys = {joker_key(j) for j in (jokers or [])}
+    shortcut = "j_shortcut" in joker_keys
+    smeared = "j_smeared" in joker_keys
+
+    # When deck_cards is unavailable, use deck_profile for rough estimates
+    def _fallback_flush_prob() -> float:
+        """Estimate flush probability from deck suit concentration."""
+        if deck_profile and deck_profile.suit_counts and deck_profile.total_cards > 0:
+            best_suit_count = max(deck_profile.suit_counts.values())
+            concentration = best_suit_count / deck_profile.total_cards
+            # ~25% = balanced suits → ~30% hit; ~50%+ concentration → ~70% hit
+            return min(0.8, max(0.15, concentration * 1.4))
+        return 0.5
+
+    def _fallback_straight_prob() -> float:
+        """Estimate straight probability from deck rank spread."""
+        if deck_profile and deck_profile.rank_counts and deck_profile.total_cards > 0:
+            # More distinct ranks = more straight potential
+            distinct = len(deck_profile.rank_counts)
+            return min(0.6, max(0.2, distinct / 13 * 0.6))
+        return 0.5
+
+    strategies: list[StrategyTuple] = []
+
+    # --- Redraw (desperation) ---
+    if chips_remaining > 0 and bh.total < chips_remaining * 0.10:
+        keep_indices = bh.card_indices
+        n_discard = min(max_discard, len(hand_cards) - len(keep_indices))
+        if n_discard > 0:
+            strategies.append((
+                "redraw",
+                keep_indices,
+                0.5,
+                f"redraw {n_discard} cards ({bh.hand_name} for {bh.total} is hopeless vs {chips_remaining} needed)",
+            ))
+
+    # --- Keep current best hand ---
+    strategies.append((
+        bh.hand_name,
+        bh.card_indices,
+        1.0,
+        f"keep {bh.hand_name}, discard dead cards",
+    ))
+
+    # --- Chase: upgrade to better hand types ---
+    def _should_chase(target: str) -> bool:
+        """True if target hand type ranks higher than current best."""
+        return HAND_INFO[target][2] < HAND_INFO[bh.hand_name][2]
+
+    # Pair (from High Card)
+    if deck_cards and _should_chase("Pair"):
+        result = pair_draw_quality(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Pair",
+                indices,
+                prob,
+                f"chase Pair ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Two Pair (from Pair) — loose: keep pair only; tight: keep pair + singleton
+    if deck_cards and _should_chase("Two Pair"):
+        result = two_pair_draw_quality(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Two Pair",
+                indices,
+                prob,
+                f"chase Two Pair loose ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+        result_tight = two_pair_draw_quality_tight(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result_tight:
+            indices, prob = result_tight
+            strategies.append((
+                "Two Pair",
+                indices,
+                prob,
+                f"chase Two Pair tight ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Three of a Kind (from Pair)
+    if deck_cards and _should_chase("Three of a Kind"):
+        result = three_kind_draw_quality(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Three of a Kind",
+                indices,
+                prob,
+                f"chase Three of a Kind ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Straight
+    if _should_chase("Straight"):
+        if deck_cards:
+            result = straight_draw_quality(hand_cards, deck_cards, shortcut=shortcut)
+            if result:
+                indices, prob = result
+                strategies.append((
+                    "Straight",
+                    indices,
+                    prob,
+                    f"chase Straight ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+                ))
+        else:
+            indices = straight_draw(hand_cards, shortcut=shortcut)
+            if indices:
+                prob = _fallback_straight_prob()
+                strategies.append((
+                    "Straight",
+                    indices,
+                    prob,
+                    f"chase Straight (~{prob:.0%}), discard {len(hand_cards) - len(indices)} cards",
+                ))
+
+    # Flush — tight: keep 4 suited; loose: keep 3 suited (when only 3 available)
+    if _should_chase("Flush"):
+        if deck_cards:
+            result = flush_draw_quality(hand_cards, deck_cards, smeared=smeared, rank_affinity=rank_affinity)
+            if result:
+                indices, prob, suit = result
+                strategies.append((
+                    "Flush",
+                    indices,
+                    prob,
+                    f"chase Flush tight ({prob:.0%} to hit, {suit}), discard {len(hand_cards) - len(indices)} cards",
+                ))
+            result_loose = flush_draw_quality_loose(hand_cards, deck_cards, smeared=smeared, rank_affinity=rank_affinity)
+            if result_loose:
+                indices, prob, suit = result_loose
+                strategies.append((
+                    "Flush",
+                    indices,
+                    prob,
+                    f"chase Flush loose ({prob:.0%} to hit, {suit}), discard {len(hand_cards) - len(indices)} cards",
+                ))
+        else:
+            indices = flush_draw(hand_cards, smeared=smeared)
+            if indices:
+                prob = _fallback_flush_prob()
+                strategies.append((
+                    "Flush",
+                    indices,
+                    prob,
+                    f"chase Flush (~{prob:.0%}), discard {len(hand_cards) - len(indices)} cards",
+                ))
+
+    # Full House — loose: trips only (any pair from deck); tight: trips + singleton (targeted)
+    if deck_cards and _should_chase("Full House"):
+        result = full_house_draw_quality(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Full House",
+                indices,
+                prob,
+                f"chase Full House loose ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+        result_tight = full_house_draw_quality_tight(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result_tight:
+            indices, prob = result_tight
+            strategies.append((
+                "Full House",
+                indices,
+                prob,
+                f"chase Full House tight ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Four of a Kind (from Three of a Kind)
+    if deck_cards and _should_chase("Four of a Kind"):
+        result = four_kind_draw_quality(hand_cards, deck_cards, rank_affinity=rank_affinity)
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Four of a Kind",
+                indices,
+                prob,
+                f"chase Four of a Kind ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Five of a Kind (from Four of a Kind)
+    if deck_cards and _should_chase("Five of a Kind"):
+        result = five_kind_draw_quality(hand_cards, deck_cards)
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Five of a Kind",
+                indices,
+                prob,
+                f"chase Five of a Kind ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Straight Flush
+    if deck_cards and _should_chase("Straight Flush"):
+        result = straight_flush_draw_quality(
+            hand_cards, deck_cards, shortcut=shortcut, smeared=smeared,
+        )
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Straight Flush",
+                indices,
+                prob,
+                f"chase Straight Flush ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Flush House (Flush + Full House)
+    if deck_cards and _should_chase("Flush House"):
+        result = flush_house_draw_quality(
+            hand_cards, deck_cards, smeared=smeared, rank_affinity=rank_affinity,
+        )
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Flush House",
+                indices,
+                prob,
+                f"chase Flush House ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # Flush Five (Flush + Five of a Kind)
+    if deck_cards and _should_chase("Flush Five"):
+        result = flush_five_draw_quality(
+            hand_cards, deck_cards, smeared=smeared, rank_affinity=rank_affinity,
+        )
+        if result:
+            indices, prob = result
+            strategies.append((
+                "Flush Five",
+                indices,
+                prob,
+                f"chase Flush Five ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
+            ))
+
+    # --- Filter by required hand (The Mouth boss) ---
+    if required_hand:
+        strategies = [
+            s for s in strategies
+            if s[0] == required_hand or s[0] == "redraw"
+        ]
+
+    return strategies

--- a/src/balatro_bot/domain/scoring/draws.py
+++ b/src/balatro_bot/domain/scoring/draws.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from math import comb
 
-from balatro_bot.cards import card_rank, card_suits, rank_value
+from balatro_bot.cards import card_rank, card_suits, is_debuffed, rank_value
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +101,49 @@ def _prob_hit(good: int, deck_size: int, draws: int) -> float:
 # Draw quality evaluation
 # ---------------------------------------------------------------------------
 
+def flush_draw_quality_loose(
+    hand_cards: list[dict], deck_cards: list[dict], smeared: bool = False,
+    rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float, str] | None:
+    """Keep 3 suited cards, need 2 more of the suit from deck.
+
+    Only activates when exactly 3 cards share a suit (not 4+, where
+    the tight variant dominates on probability).
+    """
+    suits_to_indices: dict[str, list[int]] = {}
+    for i, card in enumerate(hand_cards):
+        for suit in card_suits(card, smeared=smeared):
+            suits_to_indices.setdefault(suit, [])
+            if i not in suits_to_indices[suit]:
+                suits_to_indices[suit].append(i)
+
+    best: tuple[list[int], float, str] | None = None
+    best_prob = -1.0
+
+    for suit, indices in suits_to_indices.items():
+        if len(indices) < 3 or len(indices) >= 4:
+            continue
+        indices_sorted = sorted(
+            indices,
+            key=lambda i: (
+                0 if not is_debuffed(hand_cards[i]) else -1,
+                rank_affinity.get(card_rank(hand_cards[i]) or "", 0.0) if rank_affinity else 0.0,
+                rank_value(card_rank(hand_cards[i]) or "2"),
+            ),
+            reverse=True,
+        )
+        keep = indices_sorted[:3]
+        cards_to_draw = len(hand_cards) - len(keep)
+        suit_in_deck = sum(1 for c in deck_cards if suit in card_suits(c, smeared=smeared))
+        deck_size = len(deck_cards)
+        prob = _prob_two_or_more(suit_in_deck, deck_size, cards_to_draw)
+        if prob > best_prob:
+            best_prob = prob
+            best = (keep, prob, suit)
+
+    return best
+
+
 def flush_draw_quality(
     hand_cards: list[dict], deck_cards: list[dict], smeared: bool = False,
     rank_affinity: dict[str, float] | None = None,
@@ -120,10 +163,11 @@ def flush_draw_quality(
     for suit, indices in suits_to_indices.items():
         if len(indices) < 4:
             continue
-        if len(indices) > 4 and rank_affinity:
+        if len(indices) > 4:
             indices.sort(
                 key=lambda i: (
-                    rank_affinity.get(card_rank(hand_cards[i]) or "", 0.0),
+                    0 if not is_debuffed(hand_cards[i]) else -1,
+                    rank_affinity.get(card_rank(hand_cards[i]) or "", 0.0) if rank_affinity else 0.0,
                     rank_value(card_rank(hand_cards[i]) or "2"),
                 ),
                 reverse=True,
@@ -245,12 +289,71 @@ def two_pair_draw_quality(
             deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
 
     deck_size = len(deck_cards)
-    prob = sum(
-        _prob_two_or_more(count, deck_size, draws)
-        for count in deck_rank_counts.values()
-        if count >= 2
+
+    # Compute P(at least one rank pairs up) using inclusion-exclusion:
+    # P(miss all) = product of P(miss rank_i) for each viable rank
+    p_miss_all = 1.0
+    for count in deck_rank_counts.values():
+        if count >= 2:
+            p_hit_rank = _prob_two_or_more(count, deck_size, draws)
+            p_miss_all *= (1.0 - p_hit_rank)
+    prob = 1.0 - p_miss_all
+
+    if prob <= 0:
+        return None
+    return (keep, prob)
+
+
+def two_pair_draw_quality_tight(
+    hand_cards: list[dict], deck_cards: list[dict],
+    rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """Chase Two Pair by keeping pair + best singleton (targeted approach).
+
+    Keeps fewer draw slots than the loose variant, but targets a specific rank.
+    """
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    pairs = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) >= 2]
+    singletons = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) == 1]
+    if not pairs or not singletons:
+        return None
+
+    deck_rank_counts: dict[str, int] = {}
+    for c in deck_cards:
+        r = card_rank(c)
+        if r:
+            deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
+
+    pair_rank, pair_indices = max(
+        pairs,
+        key=lambda x: (
+            rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+            rank_value(x[0]),
+        ),
     )
-    prob = min(1.0, prob)
+
+    best_singleton_rank, best_singleton_idxs = max(
+        singletons,
+        key=lambda x: (
+            deck_rank_counts.get(x[0], 0),
+            rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+            rank_value(x[0]),
+        ),
+    )
+
+    good = deck_rank_counts.get(best_singleton_rank, 0)
+    if good <= 0:
+        return None
+
+    keep = pair_indices[:2] + best_singleton_idxs[:1]
+    draws = len(hand_cards) - len(keep)
+    deck_size = len(deck_cards)
+    prob = _prob_hit(good, deck_size, draws)
 
     if prob <= 0:
         return None
@@ -295,3 +398,520 @@ def three_kind_draw_quality(
     if prob <= 0:
         return None
     return (keep, prob)
+
+
+# ---------------------------------------------------------------------------
+# Extended draw quality functions
+# ---------------------------------------------------------------------------
+
+def pair_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+    rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """From High Card, chase a Pair.
+
+    Keep the single card whose rank has the most copies in deck (weighted by
+    affinity).  Return (keep_indices, probability).
+    """
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    # Only consider singletons — if we already have a pair, this chase is moot
+    singletons = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) == 1]
+    if not singletons:
+        return None
+
+    deck_rank_counts: dict[str, int] = {}
+    for c in deck_cards:
+        r = card_rank(c)
+        if r:
+            deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
+
+    # Pick the singleton with best combination of deck copies and affinity
+    best_rank, best_indices = max(
+        singletons,
+        key=lambda x: (
+            deck_rank_counts.get(x[0], 0),
+            rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+            rank_value(x[0]),
+        ),
+    )
+
+    good = deck_rank_counts.get(best_rank, 0)
+    if good <= 0:
+        return None
+
+    keep = best_indices[:1]
+    draws = len(hand_cards) - len(keep)
+    deck_size = len(deck_cards)
+    prob = _prob_hit(good, deck_size, draws)
+
+    if prob <= 0:
+        return None
+    return (keep, prob)
+
+
+def full_house_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+    rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """Chase Full House from Three of a Kind or Two Pair.
+
+    From Three of a Kind: keep trips, need any pair from deck (2 of same rank).
+    From Two Pair: keep both pairs, need 1 more of either pair rank.
+    Returns the better option if both exist.
+    """
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    trips = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) >= 3]
+    pairs = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) >= 2]
+
+    deck_rank_counts: dict[str, int] = {}
+    for c in deck_cards:
+        r = card_rank(c)
+        if r:
+            deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
+
+    deck_size = len(deck_cards)
+    best: tuple[list[int], float] | None = None
+    best_prob = -1.0
+
+    # Path A: From Three of a Kind — need any pair from deck
+    for trip_rank, trip_idxs in trips:
+        keep = trip_idxs[:3]
+        draws = len(hand_cards) - len(keep)
+
+        # P(at least one rank pairs up) via inclusion-exclusion
+        p_miss_all = 1.0
+        for r, count in deck_rank_counts.items():
+            if r != trip_rank and count >= 2:
+                p_miss_all *= (1.0 - _prob_two_or_more(count, deck_size, draws))
+        prob = 1.0 - p_miss_all
+        if prob > best_prob:
+            best_prob = prob
+            best = (keep, prob)
+
+    # Path B: From Two Pair — need 1 more of either pair rank
+    if len(pairs) >= 2:
+        # Pick the two best pairs by affinity
+        sorted_pairs = sorted(
+            pairs,
+            key=lambda x: (
+                rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+                rank_value(x[0]),
+            ),
+            reverse=True,
+        )
+        p1_rank, p1_idxs = sorted_pairs[0]
+        p2_rank, p2_idxs = sorted_pairs[1]
+        keep = p1_idxs[:2] + p2_idxs[:2]
+        draws = len(hand_cards) - len(keep)
+
+        good = deck_rank_counts.get(p1_rank, 0) + deck_rank_counts.get(p2_rank, 0)
+        prob = _prob_hit(good, deck_size, draws)
+        if prob > best_prob:
+            best_prob = prob
+            best = (keep, prob)
+
+    if best and best_prob > 0:
+        return best
+    return None
+
+
+def full_house_draw_quality_tight(
+    hand_cards: list[dict], deck_cards: list[dict],
+    rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """Chase Full House from trips by keeping trips + best singleton.
+
+    Targeted approach: keep trips + the singleton with most copies in deck,
+    need 1 of that rank to complete the pair. Fewer draws but specific target.
+    """
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    trips = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) >= 3]
+    if not trips:
+        return None
+
+    trip_ranks = {r for r, _ in trips}
+    companions = [(r, idxs) for r, idxs in rank_to_indices.items()
+                  if r not in trip_ranks and len(idxs) >= 1]
+    if not companions:
+        return None
+
+    deck_rank_counts: dict[str, int] = {}
+    for c in deck_cards:
+        r = card_rank(c)
+        if r:
+            deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
+
+    best: tuple[list[int], float] | None = None
+    best_prob = -1.0
+
+    for trip_rank, trip_idxs in trips:
+        best_companion_rank, best_companion_idxs = max(
+            companions,
+            key=lambda x: (
+                deck_rank_counts.get(x[0], 0),
+                rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+                rank_value(x[0]),
+            ),
+        )
+
+        good = deck_rank_counts.get(best_companion_rank, 0)
+        if good <= 0:
+            continue
+
+        keep = trip_idxs[:3] + best_companion_idxs[:1]
+        draws = len(hand_cards) - len(keep)
+        deck_size = len(deck_cards)
+        prob = _prob_hit(good, deck_size, draws)
+
+        if prob > best_prob:
+            best_prob = prob
+            best = (keep, prob)
+
+    if best and best_prob > 0:
+        return best
+    return None
+
+
+def four_kind_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+    rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """Chase Four of a Kind from Three of a Kind.
+
+    Keep trips, need the 4th copy from deck.
+    """
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    trips = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) >= 3]
+    if not trips:
+        return None
+
+    deck_rank_counts: dict[str, int] = {}
+    for c in deck_cards:
+        r = card_rank(c)
+        if r:
+            deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
+
+    # Pick the trip with best deck availability + affinity
+    trip_rank, trip_idxs = max(
+        trips,
+        key=lambda x: (
+            deck_rank_counts.get(x[0], 0),
+            rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+        ),
+    )
+
+    good = deck_rank_counts.get(trip_rank, 0)
+    if good <= 0:
+        return None
+
+    keep = trip_idxs[:3]
+    draws = len(hand_cards) - len(keep)
+    deck_size = len(deck_cards)
+    prob = _prob_hit(good, deck_size, draws)
+
+    if prob <= 0:
+        return None
+    return (keep, prob)
+
+
+def five_kind_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+) -> tuple[list[int], float] | None:
+    """Chase Five of a Kind from Four of a Kind.
+
+    Keep quads, need the 5th copy from deck.
+    """
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    quads = [(r, idxs) for r, idxs in rank_to_indices.items() if len(idxs) >= 4]
+    if not quads:
+        return None
+
+    deck_rank_counts: dict[str, int] = {}
+    for c in deck_cards:
+        r = card_rank(c)
+        if r:
+            deck_rank_counts[r] = deck_rank_counts.get(r, 0) + 1
+
+    quad_rank, quad_idxs = max(
+        quads,
+        key=lambda x: deck_rank_counts.get(x[0], 0),
+    )
+    good = deck_rank_counts.get(quad_rank, 0)
+    if good <= 0:
+        return None
+
+    keep = quad_idxs[:4]
+    draws = len(hand_cards) - len(keep)
+    deck_size = len(deck_cards)
+    prob = _prob_hit(good, deck_size, draws)
+
+    if prob <= 0:
+        return None
+    return (keep, prob)
+
+
+def straight_flush_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+    shortcut: bool = False, smeared: bool = False,
+) -> tuple[list[int], float] | None:
+    """Chase Straight Flush from 4 suited sequential cards.
+
+    Need the 5th card that is both the right rank AND the right suit.
+    """
+    # Build rank-suit index
+    rank_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        r = card_rank(c)
+        if r:
+            rank_to_indices.setdefault(r, []).append(i)
+
+    suits_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        for s in card_suits(c, smeared=smeared):
+            suits_to_indices.setdefault(s, [])
+            if i not in suits_to_indices[s]:
+                suits_to_indices[s].append(i)
+
+    rank_keys = sorted(rank_to_indices.keys(), key=rank_value)
+    max_gap = 2 if shortcut else 1
+
+    best: tuple[list[int], float] | None = None
+    best_prob = -1.0
+    deck_size = len(deck_cards)
+
+    # Find 4-card windows that are both sequential AND share a suit
+    for suit, suit_indices in suits_to_indices.items():
+        if len(suit_indices) < 4:
+            continue
+
+        # Ranks available in this suit
+        suit_ranks: dict[str, int] = {}
+        for idx in suit_indices:
+            r = card_rank(hand_cards[idx])
+            if r:
+                suit_ranks[r] = idx
+
+        sorted_ranks = sorted(suit_ranks.keys(), key=rank_value)
+
+        windows: list[list[str]] = []
+        for i in range(len(sorted_ranks) - 3):
+            window = sorted_ranks[i:i + 4]
+            vals = [rank_value(r) for r in window]
+            if all(vals[j + 1] - vals[j] <= max_gap for j in range(3)):
+                windows.append(window)
+
+        # Ace-low check
+        rank_val_set = {rank_value(r) for r in sorted_ranks}
+        if {14, 2, 3, 4} <= rank_val_set:
+            val_to_rank = {rank_value(r): r for r in sorted_ranks}
+            windows.append([val_to_rank[v] for v in (14, 2, 3, 4)])
+
+        for window in windows:
+            keep = [suit_ranks[r] for r in window]
+            draws = len(hand_cards) - len(keep)
+
+            lo = rank_value(window[0])
+            hi = rank_value(window[-1])
+            needed_ranks: set[int] = set()
+
+            if {rank_value(r) for r in window} == {14, 2, 3, 4}:
+                needed_ranks.add(5)
+            else:
+                if lo > 2:
+                    needed_ranks.add(lo - 1)
+                if hi < 14:
+                    needed_ranks.add(hi + 1)
+                if lo == 2 and hi == 5:
+                    needed_ranks.add(14)
+                if lo == 10 and hi == 13:
+                    needed_ranks.add(14)
+
+            # Need card matching BOTH the suit and one of the needed ranks
+            good = sum(
+                1 for c in deck_cards
+                if card_rank(c) and rank_value(card_rank(c)) in needed_ranks
+                and suit in card_suits(c, smeared=smeared)
+            )
+            prob = _prob_hit(good, deck_size, draws)
+
+            if prob > best_prob:
+                best_prob = prob
+                best = (keep, prob)
+
+    if best and best_prob > 0:
+        return best
+    return None
+
+
+def flush_house_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+    smeared: bool = False, rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """Chase Flush House (flush that is also a Full House).
+
+    Need 5 cards of the same suit that form a Full House (trips + pair).
+    From 4 suited cards with a pair or trips among them, need 1 more suited
+    card of the right rank.
+    """
+    suits_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        for s in card_suits(c, smeared=smeared):
+            suits_to_indices.setdefault(s, [])
+            if i not in suits_to_indices[s]:
+                suits_to_indices[s].append(i)
+
+    deck_size = len(deck_cards)
+    best: tuple[list[int], float] | None = None
+    best_prob = -1.0
+
+    for suit, indices in suits_to_indices.items():
+        if len(indices) < 4:
+            continue
+
+        # Count ranks within this suit
+        suit_rank_indices: dict[str, list[int]] = {}
+        for idx in indices:
+            r = card_rank(hand_cards[idx])
+            if r:
+                suit_rank_indices.setdefault(r, []).append(idx)
+
+        # Need a pair or trips within the suited cards
+        suit_pairs = {r: idxs for r, idxs in suit_rank_indices.items() if len(idxs) >= 2}
+        suit_trips = {r: idxs for r, idxs in suit_rank_indices.items() if len(idxs) >= 3}
+
+        # Path A: Have trips in suit — need a pair in same suit from deck
+        for trip_rank, trip_idxs in suit_trips.items():
+            keep = trip_idxs[:3]
+            # Add one more suited card if available (not of trip rank)
+            for r, idxs in suit_rank_indices.items():
+                if r != trip_rank:
+                    keep = keep + idxs[:1]
+                    break
+            if len(keep) < 4:
+                continue
+            keep = keep[:4]
+            draws = len(hand_cards) - len(keep)
+
+            # Need a card in this suit that pairs with a non-trip rank we're keeping
+            kept_ranks = [card_rank(hand_cards[i]) for i in keep if card_rank(hand_cards[i]) != trip_rank]
+            good = sum(
+                1 for c in deck_cards
+                if suit in card_suits(c, smeared=smeared)
+                and card_rank(c) in kept_ranks
+            )
+            prob = _prob_hit(good, deck_size, draws)
+            if prob > best_prob:
+                best_prob = prob
+                best = (keep, prob)
+
+        # Path B: Have pair in suit — need trips complement (2 more of a rank in suit)
+        for pair_rank, pair_idxs in suit_pairs.items():
+            if pair_rank in suit_trips:
+                continue  # Already covered by Path A
+            keep = pair_idxs[:2]
+            # Add other suited cards
+            for r, idxs in suit_rank_indices.items():
+                if r != pair_rank:
+                    for idx in idxs:
+                        if idx not in keep:
+                            keep.append(idx)
+                        if len(keep) >= 4:
+                            break
+                if len(keep) >= 4:
+                    break
+            if len(keep) < 4:
+                continue
+            keep = keep[:4]
+            draws = len(hand_cards) - len(keep)
+
+            # Need 1 more of pair_rank in this suit (gives us trips to go with existing pair)
+            good = sum(
+                1 for c in deck_cards
+                if suit in card_suits(c, smeared=smeared)
+                and card_rank(c) == pair_rank
+            )
+            prob = _prob_hit(good, deck_size, draws)
+            if prob > best_prob:
+                best_prob = prob
+                best = (keep, prob)
+
+    if best and best_prob > 0:
+        return best
+    return None
+
+
+def flush_five_draw_quality(
+    hand_cards: list[dict], deck_cards: list[dict],
+    smeared: bool = False, rank_affinity: dict[str, float] | None = None,
+) -> tuple[list[int], float] | None:
+    """Chase Flush Five (5 cards of same suit that share a rank).
+
+    Requires 4+ suited cards of the same rank in hand + 1 more from deck
+    matching both suit and rank.  Only realistic with Wild or Smeared Joker.
+    """
+    suits_to_indices: dict[str, list[int]] = {}
+    for i, c in enumerate(hand_cards):
+        for s in card_suits(c, smeared=smeared):
+            suits_to_indices.setdefault(s, [])
+            if i not in suits_to_indices[s]:
+                suits_to_indices[s].append(i)
+
+    deck_size = len(deck_cards)
+    best: tuple[list[int], float] | None = None
+    best_prob = -1.0
+
+    for suit, indices in suits_to_indices.items():
+        if len(indices) < 4:
+            continue
+
+        # Count ranks within this suit
+        suit_rank_indices: dict[str, list[int]] = {}
+        for idx in indices:
+            r = card_rank(hand_cards[idx])
+            if r:
+                suit_rank_indices.setdefault(r, []).append(idx)
+
+        # Need 4 of the same rank in this suit
+        for rank, rank_idxs in suit_rank_indices.items():
+            if len(rank_idxs) < 4:
+                continue
+            keep = rank_idxs[:4]
+            draws = len(hand_cards) - len(keep)
+
+            good = sum(
+                1 for c in deck_cards
+                if card_rank(c) == rank and suit in card_suits(c, smeared=smeared)
+            )
+            prob = _prob_hit(good, deck_size, draws)
+            if prob > best_prob:
+                best_prob = prob
+                best = (keep, prob)
+
+    if best and best_prob > 0:
+        return best
+    return None

--- a/src/balatro_bot/domain/scoring/draws.py
+++ b/src/balatro_bot/domain/scoring/draws.py
@@ -290,8 +290,8 @@ def two_pair_draw_quality(
 
     deck_size = len(deck_cards)
 
-    # Compute P(at least one rank pairs up) using inclusion-exclusion:
-    # P(miss all) = product of P(miss rank_i) for each viable rank
+    # Compute P(at least one rank pairs up) via independence approximation:
+    # P(miss all) ≈ product of P(miss rank_i) for each viable rank
     p_miss_all = 1.0
     for count in deck_rank_counts.values():
         if count >= 2:

--- a/src/balatro_bot/domain/scoring/draws.py
+++ b/src/balatro_bot/domain/scoring/draws.py
@@ -386,6 +386,7 @@ def three_kind_draw_quality(
         key=lambda x: (
             deck_rank_counts.get(x[0], 0),
             rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+            rank_value(x[0]),
         ),
     )
     keep = pair_indices[:2]
@@ -807,11 +808,17 @@ def flush_house_draw_quality(
         # Path A: Have trips in suit — need a pair in same suit from deck
         for trip_rank, trip_idxs in suit_trips.items():
             keep = trip_idxs[:3]
-            # Add one more suited card if available (not of trip rank)
-            for r, idxs in suit_rank_indices.items():
-                if r != trip_rank:
-                    keep = keep + idxs[:1]
-                    break
+            # Add the best non-trip suited card (prefer high affinity/rank)
+            other_ranks = sorted(
+                [(r, idxs) for r, idxs in suit_rank_indices.items() if r != trip_rank],
+                key=lambda x: (
+                    rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+                    rank_value(x[0]),
+                ),
+                reverse=True,
+            )
+            if other_ranks:
+                keep = keep + other_ranks[0][1][:1]
             if len(keep) < 4:
                 continue
             keep = keep[:4]
@@ -834,14 +841,18 @@ def flush_house_draw_quality(
             if pair_rank in suit_trips:
                 continue  # Already covered by Path A
             keep = pair_idxs[:2]
-            # Add other suited cards
-            for r, idxs in suit_rank_indices.items():
-                if r != pair_rank:
-                    for idx in idxs:
-                        if idx not in keep:
-                            keep.append(idx)
-                        if len(keep) >= 4:
-                            break
+            # Add other suited cards, preferring high affinity/rank
+            other_idxs = sorted(
+                [idx for r, idxs in suit_rank_indices.items()
+                 if r != pair_rank for idx in idxs if idx not in keep],
+                key=lambda idx: (
+                    rank_affinity.get(card_rank(hand_cards[idx]) or "", 0.0) if rank_affinity else 0.0,
+                    rank_value(card_rank(hand_cards[idx]) or "2"),
+                ),
+                reverse=True,
+            )
+            for idx in other_idxs:
+                keep.append(idx)
                 if len(keep) >= 4:
                     break
             if len(keep) < 4:
@@ -896,10 +907,16 @@ def flush_five_draw_quality(
             if r:
                 suit_rank_indices.setdefault(r, []).append(idx)
 
-        # Need 4 of the same rank in this suit
-        for rank, rank_idxs in suit_rank_indices.items():
-            if len(rank_idxs) < 4:
-                continue
+        # Need 4 of the same rank in this suit — prefer high affinity/rank
+        candidates = sorted(
+            [(r, idxs) for r, idxs in suit_rank_indices.items() if len(idxs) >= 4],
+            key=lambda x: (
+                rank_affinity.get(x[0], 0.0) if rank_affinity else 0.0,
+                rank_value(x[0]),
+            ),
+            reverse=True,
+        )
+        for rank, rank_idxs in candidates:
             keep = rank_idxs[:4]
             draws = len(hand_cards) - len(keep)
 

--- a/src/balatro_bot/domain/scoring/search.py
+++ b/src/balatro_bot/domain/scoring/search.py
@@ -6,7 +6,10 @@ Moved from hand_evaluator.py during Phase 2 of the logic separation refactor.
 from __future__ import annotations
 
 from itertools import combinations
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from balatro_bot.strategy import Strategy
 
 from balatro_bot.cards import card_rank, card_suit, card_suits, is_debuffed, is_joker_debuffed, is_stone, joker_key, rank_value
 from balatro_bot.constants import HAND_INFO
@@ -190,18 +193,31 @@ def cards_not_in(
     hand_cards: list[dict], keep_indices: set[int], blackboard: bool = False,
     rank_affinity: dict[str, float] | None = None,
     scoring_suit: str | None = None,
+    strategy: Strategy | None = None,
 ) -> list[int]:
     """Return indices of cards NOT in the keep set — candidates for discard.
 
     When rank_affinity is provided, high-affinity ranks are protected (sorted
     last) and negative-affinity ranks are prioritized for discard (sorted first).
     When scoring_suit is set (suit restriction bosses), off-suit cards sort earlier.
+    When strategy is provided, off-suit cards in suit-focused builds are
+    prioritized for discard (lower score = discarded first).
     """
     candidates = [i for i in range(len(hand_cards)) if i not in keep_indices]
+
+    def _suit_affinity_score(i: int) -> float:
+        if not strategy or not strategy.preferred_suits:
+            return 0.0
+        s = card_suit(hand_cards[i])
+        if not s:
+            return 0.0
+        return strategy.suit_affinity(s)
+
     candidates.sort(key=lambda i: (
         0 if is_debuffed(hand_cards[i]) else 1,
         0 if blackboard and card_suit(hand_cards[i]) in ("H", "D") else 1,
         1 if scoring_suit and scoring_suit in card_suits(hand_cards[i]) else 0 if not scoring_suit else -1,
+        _suit_affinity_score(i),
         rank_affinity.get(card_rank(hand_cards[i]) or "", 0.0) if rank_affinity else 0,
         rank_value(card_rank(hand_cards[i]) or "2"),
     ))
@@ -346,7 +362,7 @@ def discard_candidates(
     has_blackboard = any(joker_key(j) == "j_blackboard" for j in (jokers or []))
 
     for chase_name, keep, prob, reason in strategies:
-        to_discard = cards_not_in(hand_cards, set(keep), blackboard=has_blackboard, rank_affinity=rank_aff)[:max_discard]
+        to_discard = cards_not_in(hand_cards, set(keep), blackboard=has_blackboard, rank_affinity=rank_aff, strategy=strat)[:max_discard]
         if to_discard:
             results.append(ChaseCandidate(to_discard, reason, chase_name, list(keep), prob))
 

--- a/src/balatro_bot/domain/scoring/search.py
+++ b/src/balatro_bot/domain/scoring/search.py
@@ -15,14 +15,7 @@ from balatro_bot.cards import card_rank, card_suit, card_suits, is_debuffed, is_
 from balatro_bot.constants import HAND_INFO
 
 from balatro_bot.domain.scoring.classify import classify_hand, _scoring_cards_for
-from balatro_bot.domain.scoring.draws import (
-    flush_draw,
-    flush_draw_quality,
-    straight_draw,
-    straight_draw_quality,
-    two_pair_draw_quality,
-    three_kind_draw_quality,
-)
+from balatro_bot.domain.scoring.chase import generate_chases
 from balatro_bot.domain.scoring.estimate import score_hand
 
 
@@ -214,11 +207,16 @@ def cards_not_in(
         return strategy.suit_affinity(s)
 
     candidates.sort(key=lambda i: (
-        0 if is_debuffed(hand_cards[i]) else 1,
-        0 if blackboard and card_suit(hand_cards[i]) in ("H", "D") else 1,
+        # 1. Hard constraints (boss/joker mechanics) — protect required cards
         1 if scoring_suit and scoring_suit in card_suits(hand_cards[i]) else 0 if not scoring_suit else -1,
+        0 if blackboard and card_suit(hand_cards[i]) in ("H", "D") else 1,
+        # 2. Strategic value — protect cards the strategy wants to keep
         _suit_affinity_score(i),
         rank_affinity.get(card_rank(hand_cards[i]) or "", 0.0) if rank_affinity else 0,
+        # 3. Debuff as tiebreaker — debuffed junk goes first, but debuffed
+        #    cards with strategic value are protected by layers above
+        0 if is_debuffed(hand_cards[i]) else 1,
+        # 4. Raw card value — higher rank cards survive longer
         rank_value(card_rank(hand_cards[i]) or "2"),
     ))
     return candidates
@@ -234,119 +232,52 @@ def discard_candidates(
     chips_remaining: int = 0,
     jokers: list[dict] | None = None,
     required_hand: str | None = None,
+    deck_profile=None,
 ) -> list[ChaseCandidate]:
     """Suggest discard sets that improve toward better hands."""
     bh = best_hand(hand_cards, hand_levels, max_select, jokers=jokers, required_hand=required_hand)
     if not bh:
-        return [(list(range(min(max_discard, len(hand_cards)))), "no hand found")]
-
-    joker_keys = {joker_key(j) for j in (jokers or [])}
-    shortcut = "j_shortcut" in joker_keys
-    smeared = "j_smeared" in joker_keys
+        fallback = list(range(min(max_discard, len(hand_cards))))
+        return [ChaseCandidate(fallback, "no hand found", "High Card", [], 0.0)]
 
     from balatro_bot.strategy import compute_strategy
     strat = compute_strategy(jokers or [], hand_levels)
     rank_aff = strat.rank_affinity_dict() or None
 
-    strategies: list[tuple[str, list[int], float, str]] = []
-
-    if chips_remaining > 0 and bh.total < chips_remaining * 0.10:
-        keep_indices = bh.card_indices
-        n_discard = min(max_discard, len(hand_cards) - len(keep_indices))
-        if n_discard > 0:
-            strategies.append((
-                "redraw",
-                keep_indices,
-                0.5,
-                f"redraw {n_discard} cards ({bh.hand_name} for {bh.total} is hopeless vs {chips_remaining} needed)",
-            ))
-
-    strategies.append((
-        bh.hand_name,
-        bh.card_indices,
-        1.0,
-        f"keep {bh.hand_name}, discard dead cards",
-    ))
-
-    if HAND_INFO["Flush"][2] < HAND_INFO[bh.hand_name][2]:
-        if deck_cards:
-            fdq = flush_draw_quality(hand_cards, deck_cards, smeared=smeared, rank_affinity=rank_aff)
-            if fdq:
-                indices, prob, suit = fdq
-                strategies.append((
-                    "Flush",
-                    indices,
-                    prob,
-                    f"chase Flush ({prob:.0%} to hit, {suit}), discard {len(hand_cards) - len(indices)} cards",
-                ))
-        else:
-            flush_indices = flush_draw(hand_cards, smeared=smeared)
-            if flush_indices:
-                strategies.append((
-                    "Flush",
-                    flush_indices,
-                    0.5,
-                    f"chase Flush, discard {len(hand_cards) - len(flush_indices)} cards",
-                ))
-
-    if HAND_INFO["Straight"][2] < HAND_INFO[bh.hand_name][2]:
-        if deck_cards:
-            sdq = straight_draw_quality(hand_cards, deck_cards, shortcut=shortcut)
-            if sdq:
-                indices, prob = sdq
-                strategies.append((
-                    "Straight",
-                    indices,
-                    prob,
-                    f"chase Straight ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
-                ))
-        else:
-            straight_indices = straight_draw(hand_cards, shortcut=shortcut)
-            if straight_indices:
-                strategies.append((
-                    "Straight",
-                    straight_indices,
-                    0.5,
-                    f"chase Straight, discard {len(hand_cards) - len(straight_indices)} cards",
-                ))
-
-    if deck_cards and HAND_INFO["Two Pair"][2] < HAND_INFO[bh.hand_name][2]:
-        tpdq = two_pair_draw_quality(hand_cards, deck_cards, rank_affinity=rank_aff)
-        if tpdq:
-            indices, prob = tpdq
-            strategies.append((
-                "Two Pair",
-                indices,
-                prob,
-                f"chase Two Pair ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
-            ))
-
-    if deck_cards and HAND_INFO["Three of a Kind"][2] < HAND_INFO[bh.hand_name][2]:
-        tkdq = three_kind_draw_quality(hand_cards, deck_cards, rank_affinity=rank_aff)
-        if tkdq:
-            indices, prob = tkdq
-            strategies.append((
-                "Three of a Kind",
-                indices,
-                prob,
-                f"chase Three of a Kind ({prob:.0%} to hit), discard {len(hand_cards) - len(indices)} cards",
-            ))
-
-    if required_hand:
-        strategies = [
-            (n, k, p, r) for n, k, p, r in strategies
-            if n == required_hand or n == "redraw"
-        ]
+    strategies = generate_chases(
+        hand_cards, bh,
+        hand_levels=hand_levels,
+        deck_cards=deck_cards,
+        jokers=jokers,
+        chips_remaining=chips_remaining,
+        max_discard=max_discard,
+        rank_affinity=rank_aff,
+        required_hand=required_hand,
+        deck_profile=deck_profile,
+    )
 
     has_any_affinity = strategy_affinity and any(v > 0 for v in strategy_affinity.values())
 
-    def chase_score(strategy: tuple[str, list[int], float, str]) -> float:
-        hand_name, _, prob, _ = strategy
-        if hand_name == "redraw":
-            return 150 * prob
+    def _leveled_value(hand_name: str) -> float:
+        """Return chips * mult for a hand using real hand levels."""
+        base_chips, base_mult, _ = HAND_INFO[hand_name]
+        if hand_levels and hand_name in hand_levels:
+            lvl = hand_levels[hand_name]
+            base_chips = lvl.get("chips", base_chips)
+            base_mult = lvl.get("mult", base_mult)
+        return base_chips * base_mult
 
-        chips, mult, _ = HAND_INFO[hand_name]
-        base = chips * mult * prob
+    def chase_score(strategy: tuple[str, list[int], float, str]) -> float:
+        hand_name, keep, prob, _ = strategy
+        if hand_name == "redraw":
+            keep_cards = [hand_cards[i] for i in keep]
+            _, _, total = score_hand(
+                bh.hand_name, keep_cards,
+                hand_levels=hand_levels, jokers=jokers,
+            )
+            return total * prob
+
+        base = _leveled_value(hand_name) * prob
 
         if has_any_affinity:
             affinity = strategy_affinity.get(hand_name, 0)

--- a/src/balatro_bot/engine.py
+++ b/src/balatro_bot/engine.py
@@ -15,7 +15,8 @@ from balatro_bot.rules import (
     BuyVouchersInShop, RerollShop, LeaveShop,
     AlwaysCashOut,
     SkipPackForRedCard, PickFromTarotPack, PickFromPlanetPack,
-    PickFromBuffoonPack, PickFromSpectralPack, PickBestFromPack,
+    PickFromBuffoonPack, PickFromSpectralPack, PickFromStandardPack,
+    PickBestFromPack,
     UseConsumables,
 )
 
@@ -59,7 +60,7 @@ DEFAULT_RULES: dict[str, list[Rule]] = {
     "TAROT_PACK": [SkipPackForRedCard(), PickFromTarotPack(), PickBestFromPack()],
     "PLANET_PACK": [PickFromPlanetPack(), PickBestFromPack()],
     "SPECTRAL_PACK": [SkipPackForRedCard(), PickBestFromPack()],
-    "STANDARD_PACK": [SkipPackForRedCard(), PickBestFromPack()],
+    "STANDARD_PACK": [SkipPackForRedCard(), PickFromStandardPack(), PickBestFromPack()],
     "BUFFOON_PACK": [PickFromBuffoonPack(), PickBestFromPack()],
     "SMODS_BOOSTER_OPENED": [
         SkipPackForRedCard(), PickFromTarotPack(), PickFromPlanetPack(),

--- a/src/balatro_bot/joker_effects/complex.py
+++ b/src/balatro_bot/joker_effects/complex.py
@@ -58,7 +58,11 @@ def _misprint(ctx: ScoreContext, j: dict) -> None:
     ab = _ability(j)
     lo = ab.get("min", 0)
     hi = ab.get("max", 23)
-    ctx.mult += (lo + hi) / 2
+    # Risk-adjusted: with fewer hands left, estimate conservatively.
+    # percentile 0.0 = lo, 1.0 = hi, 0.5 = midpoint (EV).
+    # 1 hand → 25th percentile, 4+ hands → midpoint.
+    pct = min(ctx.hands_left / 4, 1.0) * 0.5
+    ctx.mult += lo + (hi - lo) * pct
 
 def _raised_fist(ctx: ScoreContext, j: dict) -> None:
     # Raised Fist uses chip values (J/Q/K=10, A=11), not rank order (J=11..A=14)

--- a/src/balatro_bot/rules/__init__.py
+++ b/src/balatro_bot/rules/__init__.py
@@ -14,7 +14,8 @@ from balatro_bot.rules.shop import (
 from balatro_bot.rules.round_eval import AlwaysCashOut
 from balatro_bot.rules.packs import (
     SkipPackForRedCard, PickFromTarotPack, PickFromPlanetPack,
-    PickFromBuffoonPack, PickFromSpectralPack, PickBestFromPack,
+    PickFromBuffoonPack, PickFromSpectralPack, PickFromStandardPack,
+    PickBestFromPack,
 )
 from balatro_bot.rules.consumables import UseConsumables
 
@@ -28,6 +29,7 @@ __all__ = [
     "BuyVouchersInShop", "RerollShop", "LeaveShop",
     "AlwaysCashOut",
     "SkipPackForRedCard", "PickFromTarotPack", "PickFromPlanetPack",
-    "PickFromBuffoonPack", "PickFromSpectralPack", "PickBestFromPack",
+    "PickFromBuffoonPack", "PickFromSpectralPack", "PickFromStandardPack",
+    "PickBestFromPack",
     "UseConsumables",
 ]

--- a/src/balatro_bot/rules/_helpers.py
+++ b/src/balatro_bot/rules/_helpers.py
@@ -297,13 +297,25 @@ def _find_stone_targets(hand_cards, count, jokers, rank_affinity=None):
     return [i for i, _, _ in candidates[:count]]
 
 
-def _find_destroy_targets(hand_cards, count, rank_affinity=None):
+def _find_destroy_targets(hand_cards, count, rank_affinity=None, strategy=None):
     candidates = []
     for i, c in enumerate(hand_cards):
         r = card_rank(c)
         if r and not _modifier(c).get("enhancement"):
-            aff = rank_affinity.get(r, 0.0) if rank_affinity else 0.0
-            candidates.append((i, aff, rank_value(r)))  # low/negative affinity first
+            # Base score from rank affinity (low affinity → destroy first)
+            score = rank_affinity.get(r, 0.0) if rank_affinity else 0.0
+
+            # Suit-awareness: off-suit cards in suit builds are prime targets
+            if strategy and strategy.preferred_suits:
+                s = card_suit(c)
+                if s:
+                    suit_aff = strategy.suit_affinity(s)
+                    if suit_aff > 0:
+                        score += 3.0   # protect on-suit cards
+                    elif suit_aff <= 0:
+                        score -= 2.0   # target off-suit cards
+
+            candidates.append((i, score, rank_value(r)))
     candidates.sort(key=lambda x: (x[1], x[2]))
     return [i for i, _, _ in candidates[:count]]
 
@@ -422,7 +434,8 @@ def _find_tarot_targets(effect_type, extra, max_count, hand_cards, jokers, strat
         targets = _find_stone_targets(hand_cards, max_count, jokers, rank_affinity=rank_aff)
         return (targets, 1.5) if targets else (None, 0)
     if effect_type == "destroy":
-        targets = _find_destroy_targets(hand_cards, max_count, rank_affinity=rank_aff)
+        targets = _find_destroy_targets(hand_cards, max_count, rank_affinity=rank_aff,
+                                        strategy=strat)
         return (targets, 1.0) if targets else (None, 0)
     if effect_type == "clone":
         targets = _find_clone_targets(hand_cards, strat)

--- a/src/balatro_bot/rules/_helpers.py
+++ b/src/balatro_bot/rules/_helpers.py
@@ -26,23 +26,27 @@ def _pad_with_junk(
     jokers: list[dict],
     intended_hand: str = "",
     max_cards: int = 5,
+    strategy: Strategy | None = None,
+    scoring_suit: str | None = None,
 ) -> list[int]:
-    """Pad a hand with low-value junk cards for free deck cycling.
+    """Pad a hand with junk cards for free deck cycling.
 
-    If intended_hand is provided, each candidate junk card is checked to
-    ensure it doesn't change the hand classification (e.g. turning a High
-    Card into a Pair, or creating an accidental Flush/Straight).  If we
-    can't fill to target without changing the hand, we play fewer cards.
+    Uses the same strategic discard ordering as the discard system —
+    cards we'd most want to discard are the first ones cycled out via play.
+    If intended_hand is provided, each candidate is checked to ensure it
+    doesn't change the hand classification.
     """
-    joker_keys = {joker_key(j) for j in jokers}
+    from balatro_bot.domain.scoring.search import cards_not_in
+
+    jk = {joker_key(j) for j in jokers}
     n = len(card_indices)
 
-    if joker_keys & FEWER_CARDS_JOKERS and n <= 3:
+    if jk & FEWER_CARDS_JOKERS and n <= 3:
         return card_indices
-    if joker_keys & ALL_SCORE_JOKERS:
+    if jk & ALL_SCORE_JOKERS:
         return card_indices
 
-    if joker_keys & EXACT_4_JOKERS:
+    if jk & EXACT_4_JOKERS:
         target = 4
     else:
         target = max_cards
@@ -50,9 +54,21 @@ def _pad_with_junk(
     if n >= target:
         return card_indices
 
-    four_fingers = "j_four_fingers" in joker_keys
-    shortcut = "j_shortcut" in joker_keys
-    smeared = "j_smeared" in joker_keys
+    four_fingers = "j_four_fingers" in jk
+    shortcut = "j_shortcut" in jk
+    smeared = "j_smeared" in jk
+
+    has_blackboard = "j_blackboard" in jk
+    rank_affinity = strategy.rank_affinity_dict() if strategy else None
+
+    # cards_not_in returns non-keep indices sorted worst-first (discard priority)
+    junk_priority = cards_not_in(
+        hand_cards, set(card_indices),
+        blackboard=has_blackboard,
+        rank_affinity=rank_affinity,
+        scoring_suit=scoring_suit,
+        strategy=strategy,
+    )
 
     # For High Card, junk must not outrank the scoring card or it becomes
     # the new scoring card (game picks highest rank, leftmost on ties).
@@ -61,22 +77,14 @@ def _pad_with_junk(
         scoring_rank = rank_value(card_rank(hand_cards[card_indices[0]]) or "2")
         max_junk_rank = scoring_rank
 
-    used = set(card_indices)
-    junk = []
-    for i, c in enumerate(hand_cards):
-        if i not in used:
-            r = card_rank(c)
-            rv = rank_value(r) if r else 0
-            debuffed = is_debuffed(c)
-            if max_junk_rank is not None and rv > max_junk_rank:
-                continue
-            junk.append((i, 0 if debuffed else 1, rv))
-    junk.sort(key=lambda x: (x[1], x[2]))
-
     padded = list(card_indices)
-    for i, _, _ in junk:
+    for i in junk_priority:
         if len(padded) >= target:
             break
+        if max_junk_rank is not None:
+            rv = rank_value(card_rank(hand_cards[i]) or "2")
+            if rv > max_junk_rank:
+                continue
         if intended_hand:
             test_cards = [hand_cards[j] for j in padded] + [hand_cards[i]]
             if classify_hand(test_cards, four_fingers, shortcut, smeared) != intended_hand:

--- a/src/balatro_bot/rules/packs.py
+++ b/src/balatro_bot/rules/packs.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from balatro_bot.actions import PackAction, Action
-from balatro_bot.cards import joker_key
+from balatro_bot.cards import card_rank, card_suit, joker_key
 from balatro_bot.constants import (
     NO_TARGET_TAROTS, TARGETING_TAROTS, PLANET_HAND_MAP, PLANET_KEYS,
     SAFE_SPECTRAL_CONSUMABLES, SPECTRAL_TARGETING,
@@ -158,10 +158,11 @@ class PickFromBuffoonPack:
         joker_limit = joker_slots.get("limit", 5)
         strat = compute_strategy(owned_jokers, hand_levels)
 
-        from balatro_bot.domain.policy.shop import ALWAYS_BUY
+        from balatro_bot.domain.policy.shop import ALWAYS_BUY, _get_deck_profile
         best_idx, best_score, reason = choose_from_buffoon_pack(
             cards, owned_jokers, hand_levels, ante, joker_limit, strat,
             always_buy_keys=ALWAYS_BUY,
+            deck_profile=_get_deck_profile(state),
         )
 
         return PackAction(card_index=best_idx, reason=reason)
@@ -201,6 +202,80 @@ class PickFromSpectralPack:
             return PackAction(card_index=best_idx, targets=targets, reason=reason)
 
         return PackAction(card_index=best_idx, reason=reason)
+
+
+class PickFromStandardPack:
+    """Evaluate Standard pack cards against strategy; pick or skip."""
+    name = "pick_from_standard_pack"
+
+    # Minimum score for a card to be worth picking (vs diluting the deck)
+    _PICK_THRESHOLD = 2.0
+
+    # Bonus for editions/enhancements/seals on Standard pack cards
+    _EDITION_BONUS = {"POLYCHROME": 8.0, "HOLOGRAPHIC": 4.0, "FOIL": 2.0}
+    _ENHANCEMENT_BONUS = {
+        "STEEL": 5.0, "GLASS": 4.0, "LUCKY": 3.0, "MULT": 3.0,
+        "WILD": 2.0, "BONUS": 2.0, "GOLD": 2.0,
+    }
+    _SEAL_BONUS = {"GOLD": 3.0, "RED": 4.0, "BLUE": 2.0, "PURPLE": 2.0}
+
+    def evaluate(self, state: dict[str, Any]) -> Action | None:
+        pack = state.get("pack", {})
+        cards = pack.get("cards", [])
+        if not cards:
+            return None
+
+        # Only handle Standard packs — cards should be playing cards
+        if not all(c.get("set") in ("DEFAULT", "PLAYING_CARD", None) for c in cards):
+            return None
+
+        jokers = state.get("jokers", {}).get("cards", [])
+        hand_levels = state.get("hands", {})
+        strat = compute_strategy(jokers, hand_levels)
+
+        best_idx = None
+        best_score = -1.0
+
+        for i, card in enumerate(cards):
+            score = 0.0
+
+            # Suit affinity
+            suit = card_suit(card)
+            if suit and strat.preferred_suits:
+                score += strat.suit_affinity(suit) * 1.5
+
+            # Rank affinity
+            rank = card_rank(card)
+            if rank:
+                score += strat.rank_affinity(rank) * 1.0
+
+            # Edition/enhancement/seal bonuses
+            mod = card.get("modifier", {})
+            if isinstance(mod, dict):
+                edition = mod.get("edition")
+                if edition:
+                    score += self._EDITION_BONUS.get(edition.upper(), 0.0)
+                enhancement = mod.get("enhancement")
+                if enhancement:
+                    score += self._ENHANCEMENT_BONUS.get(enhancement.upper(), 0.0)
+                seal = mod.get("seal")
+                if seal:
+                    score += self._SEAL_BONUS.get(seal.upper(), 0.0)
+
+            if score > best_score:
+                best_score = score
+                best_idx = i
+
+        if best_idx is not None and best_score >= self._PICK_THRESHOLD:
+            c = cards[best_idx]
+            label = c.get("label", "?")
+            log.info("Standard pack: pick %s (score=%.1f)", label, best_score)
+            return PackAction(
+                card_index=best_idx,
+                reason=f"standard pack: pick {label} (value={best_score:.1f})",
+            )
+
+        return PackAction(card_index=None, reason="skip standard pack (no strategic value)")
 
 
 class PickBestFromPack:

--- a/src/balatro_bot/scaling.py
+++ b/src/balatro_bot/scaling.py
@@ -247,6 +247,7 @@ ANTI_SYNERGY: dict[str, frozenset[str]] = {
     # Slot conflicts
     "j_stencil":        frozenset({"j_abstract", "j_riff_raff"}),
     "j_abstract":       frozenset({"j_stencil"}),
+    "j_riff_raff":      frozenset({"j_stencil"}),
     # Enhancement conflicts
     "j_vampire":        frozenset({"j_glass", "j_lucky_cat"}),
     # Strategy conflicts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,9 @@ def card_with_perma(rank: str, suit: str, perma_bonus: int, enhancement: str | N
     )
 
 
-def joker(key: str, label: str = "") -> dict:
+def joker(key: str, label: str = "", rarity: int | str | None = None) -> dict:
     """Build a minimal joker dict."""
-    return {"key": key, "label": label or key, "set": "JOKER", "cost": {"sell": 3}}
+    j: dict = {"key": key, "label": label or key, "set": "JOKER", "cost": {"sell": 3}}
+    if rarity is not None:
+        j.setdefault("value", {})["rarity"] = rarity
+    return j

--- a/tests/integration/support/harness.py
+++ b/tests/integration/support/harness.py
@@ -662,6 +662,31 @@ def burn_discards(client: BalatroClient, target_discards: int = 20) -> None:
     print(f"    Burned {discarded} cards via discard")
 
 
+def setup_god_mode_ante8(client: BalatroClient, seed: str) -> dict:
+    """Cheat to ante 8 boss, inject god-mode jokers, let bot play with 4 hands."""
+    setup_game(client, seed=seed)
+    advance_to_boss_select(client, target_ante=8)
+
+    state = client.call("gamestate")
+    print(f"\n  Ante 8 boss: {get_boss_name(state)}")
+
+    if state.get("state") == "BLIND_SELECT":
+        client.call("select")
+        time.sleep(0.5)
+        state = wait_for_state(client, {"SELECTING_HAND"})
+
+    # Sell existing jokers to make room for god-mode ones
+    joker_count = state.get("jokers", {}).get("count", 0)
+    for _ in range(joker_count):
+        try:
+            client.call("sell", {"joker": 0})
+        except APIError:
+            pass
+
+    inject_god_mode_complex(client)
+    return client.call("gamestate")
+
+
 def snapshot_jokers(state: dict, track_keys: set[str]) -> dict:
     """Snapshot ability dicts for tracked joker keys."""
     snap = {}

--- a/tests/integration/support/harness.py
+++ b/tests/integration/support/harness.py
@@ -579,6 +579,50 @@ def inject_god_mode(client: BalatroClient, *,
             print(f"    FAILED adding {jk}: {e.message}")
 
 
+def inject_god_mode_complex(client: BalatroClient, *,
+                            saturn_levels: int = 15) -> None:
+    """Inject a complex build: level Straight to 15, add 9 jokers with editions.
+
+    All negative-edition jokers don't consume slots, so this fits in 5 slots.
+    The scoring chain: Pareidolia makes every card count as every suit/rank,
+    Four Fingers makes 4-card straights valid, Shortcut allows gaps in straights,
+    then Devious/Cavendish/Card Sharp/Hanging Chad/The Order provide massive mult.
+    """
+    # Level up Straight via Saturn (planet card for Straight)
+    leveled = 0
+    for _ in range(saturn_levels):
+        try:
+            client.call("add", {"key": "c_saturn"})
+            client.call("use", {"consumable": 0})
+            leveled += 1
+        except APIError:
+            break
+        time.sleep(0.15)
+    print(f"    Leveled Straight {leveled} times")
+
+    # Jokers with their editions
+    # Negative edition jokers don't take a slot (+1 joker slot each)
+    jokers = [
+        ("j_shortcut",        "NEGATIVE"),
+        ("j_four_fingers",    "NEGATIVE"),
+        ("j_sock_and_buskin", "NEGATIVE"),
+        ("j_pareidolia",      "NEGATIVE"),
+        ("j_devious",         "POLYCHROME"),
+        ("j_cavendish",       "POLYCHROME"),
+        ("j_card_sharp",      "NEGATIVE"),
+        ("j_hanging_chad",    "POLYCHROME"),
+        ("j_order",           "POLYCHROME"),
+    ]
+
+    for key, edition in jokers:
+        try:
+            client.call("add", {"key": key, "edition": edition})
+            print(f"    Added {key} ({edition})")
+        except APIError as e:
+            print(f"    FAILED adding {key}: {e.message}")
+        time.sleep(0.15)
+
+
 def inject_milk_trigger(client: BalatroClient) -> None:
     """Add Green Joker (milk_priority=3) to force milking behavior."""
     try:

--- a/tests/integration/test_win_crash.py
+++ b/tests/integration/test_win_crash.py
@@ -1,0 +1,171 @@
+"""Integration test: bot survives the win screen without crashing.
+
+Reproduces game_102 crash (2026-04-11):
+  Bot beats ante 8 boss → cash_out triggers the win screen →
+  mod becomes unresponsive → double timeout → crash.
+
+Cheats to ante 8 boss select, sells jokers, burns hands down to 1,
+then injects polychrome god-mode jokers so the bot one-shots the boss.
+When the win screen fires, the bot should exit gracefully.
+
+MUST run headed — the post-win timeout is caused by the Lua mod's
+UI event handling after G.GAME.won fires.
+
+Usage:
+    python test_win_crash.py [--port PORT]
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
+
+from balatrobot.cli.client import BalatroClient, APIError
+from balatro_bot.engine import RuleEngine
+from balatro_bot.bot import run_bot, setup_logging
+from harness import (
+    start_server, stop_server, setup_game, inject_jokers,
+    advance_to_boss_select, get_boss_name, wait_for_state,
+    TEST_PORT, _check_port,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test: bot exits gracefully on win screen (no crash on double timeout)"
+    )
+    parser.add_argument("--port", type=int, default=TEST_PORT)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    # Must be headed — post-win timeout only happens with the real game UI
+    server_proc = None
+    if _check_port(args.port):
+        print(f"  Server already running on port {args.port}")
+        client = BalatroClient(port=args.port)
+    else:
+        server_proc = start_server(port=args.port, headless=False, fast=True)
+        client = BalatroClient(port=args.port)
+
+    try:
+        _run_test(client)
+    finally:
+        if server_proc:
+            stop_server(server_proc)
+
+
+def _run_test(client: BalatroClient):
+    print("\n" + "=" * 60)
+    print("TEST: Bot survives the win screen")
+    print("=" * 60)
+
+    # Start fresh game, cheat to ante 8 boss select
+    setup_game(client, seed="WINCRASH1")
+    advance_to_boss_select(client, target_ante=8)
+
+    state = client.call("gamestate")
+    print(f"\n  Ante 8 boss: {get_boss_name(state)}")
+    print(f"  State: {state.get('state')}")
+
+    # Select the boss so we're in SELECTING_HAND
+    if state.get("state") == "BLIND_SELECT":
+        client.call("select")
+        time.sleep(0.5)
+        state = wait_for_state(client, {"SELECTING_HAND"})
+
+    # Sell all existing jokers
+    joker_count = state.get("jokers", {}).get("count", 0)
+    for _ in range(joker_count):
+        try:
+            client.call("sell", {"joker": 0})
+        except APIError:
+            pass
+    print(f"  Sold {joker_count} jokers")
+
+    # Burn hands down to 1 by playing garbage
+    state = client.call("gamestate")
+    hands_left = state.get("round", {}).get("hands_left", 4)
+    while hands_left > 1:
+        hand_cards = state.get("hand", {}).get("cards", [])
+        n = min(5, len(hand_cards))
+        if n == 0:
+            break
+        try:
+            client.call("play", {"cards": list(range(n))})
+        except APIError:
+            break
+        time.sleep(0.3)
+        state = client.call("gamestate")
+        # Wait through transition states
+        for _ in range(10):
+            if state.get("state") == "SELECTING_HAND":
+                break
+            time.sleep(0.2)
+            state = client.call("gamestate")
+        hands_left = state.get("round", {}).get("hands_left", 0)
+    print(f"  Hands remaining: {hands_left}")
+
+    # Inject polychrome god-mode jokers
+    poly_jokers = [
+        "j_photograph", "j_triboulet", "j_smiley",
+        "j_scary_face", "j_pareidolia",
+    ]
+    for jk in poly_jokers:
+        try:
+            client.call("add", {"key": jk, "edition": "POLYCHROME"})
+            print(f"    Added {jk} (Polychrome)")
+        except APIError as e:
+            print(f"    FAILED adding {jk}: {e.message}")
+
+    # Level up High Card massively so any 5-card hand one-shots the boss
+    leveled = 0
+    for _ in range(50):
+        try:
+            client.call("add", {"key": "c_pluto"})
+            client.call("use", {"consumable": 0})
+            leveled += 1
+        except APIError:
+            break
+    print(f"    Leveled High Card {leveled} times")
+
+    state = client.call("gamestate")
+    jokers = [j.get("label", "?") for j in state.get("jokers", {}).get("cards", [])]
+    print(f"\n  Roster: {jokers}")
+    print(f"  Hands left: {state.get('round', {}).get('hands_left')}")
+
+    # Let the bot play — one hand to beat the boss, then win screen fires
+    print("\n  Running bot — expecting win screen survival...")
+    engine = RuleEngine()
+
+    try:
+        won = run_bot(client, engine, start_game=False, poll_interval=0.15)
+    except Exception as e:
+        print(f"\n  FAIL: Bot crashed with {type(e).__name__}: {e}")
+        print("=" * 60)
+        sys.exit(1)
+
+    print()
+    print("=" * 60)
+    if won:
+        print("PASS: Bot returned won=True (survived win screen)")
+    else:
+        print("PARTIAL: Bot didn't crash, but returned won=False")
+        print("  (victory detection may need further work)")
+    print("=" * 60)
+
+    if not won:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_win_multigame_bug.py
+++ b/tests/integration/test_win_multigame_bug.py
@@ -1,0 +1,171 @@
+"""Integration test: reproduces game_103 crash — server dies after win screen.
+
+Reproduces the multi-game crash (2026-04-12):
+  Bot beats ante 8 boss → run_bot returns won=True →
+  server is dead (ConnectError) → next game start fails.
+
+The existing test_win_crash.py only runs ONE game, so it never
+catches this. This test runs TWO games:
+  1. Cheat to win at ante 8, run the bot
+  2. Verify the server is still alive
+  3. Start a second game
+
+MUST run headed — the win-screen hang only triggers with the real UI.
+
+Usage:
+    python test_win_multigame_bug.py [--port PORT]
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
+
+from balatrobot.cli.client import BalatroClient, APIError
+from balatro_bot.engine import RuleEngine
+from balatro_bot.bot import run_bot, setup_logging
+from harness import (
+    start_server, stop_server, setup_game, inject_god_mode_complex,
+    advance_to_boss_select, get_boss_name, wait_for_state,
+    TEST_PORT, _check_port,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test: server survives win screen for multi-game loop"
+    )
+    parser.add_argument("--port", type=int, default=TEST_PORT)
+    args = parser.parse_args()
+
+    # Match stream mode logging exactly — setup_logging with stream_file
+    log_dir = os.path.join(os.path.dirname(__file__), "..", "..", "logs", "test_multigame_bug")
+    os.makedirs(log_dir, exist_ok=True)
+    setup_logging(
+        log_file=os.path.join(log_dir, "game.log"),
+        wins_file=os.path.join(log_dir, "wins.txt"),
+        scoring_file=os.path.join(log_dir, "scoring.log"),
+        stream_file=os.path.join(log_dir, "stream.log"),
+    )
+
+    server_proc = None
+    if _check_port(args.port):
+        print(f"  Server already running on port {args.port}")
+        client = BalatroClient(port=args.port)
+    else:
+        # fast=False to match stream mode — the bug only triggers with normal
+        # animation speed (fast mode skips the win animation that causes the hang)
+        server_proc = start_server(port=args.port, headless=False, fast=False)
+        client = BalatroClient(port=args.port)
+
+    try:
+        _run_test(client)
+    finally:
+        if server_proc:
+            stop_server(server_proc)
+
+
+def _setup_god_mode_ante8(client: BalatroClient, seed: str) -> dict:
+    """Cheat to ante 8 boss, inject god-mode jokers, let bot play with 4 hands."""
+    setup_game(client, seed=seed)
+    advance_to_boss_select(client, target_ante=8)
+
+    state = client.call("gamestate")
+    print(f"\n  Ante 8 boss: {get_boss_name(state)}")
+
+    if state.get("state") == "BLIND_SELECT":
+        client.call("select")
+        time.sleep(0.5)
+        state = wait_for_state(client, {"SELECTING_HAND"})
+
+    # Sell existing jokers to make room for god-mode ones
+    joker_count = state.get("jokers", {}).get("count", 0)
+    for _ in range(joker_count):
+        try:
+            client.call("sell", {"joker": 0})
+        except APIError:
+            pass
+
+    inject_god_mode_complex(client)
+    return client.call("gamestate")
+
+
+def _run_test(client: BalatroClient):
+    print("\n" + "=" * 60)
+    print("TEST: Server survives win screen for multi-game loop")
+    print("=" * 60)
+
+    # ---- Game 1: win at ante 8 ----
+    print("\n--- GAME 1: Win at ante 8 ---")
+    _setup_god_mode_ante8(client, seed="MULTIGAME1")
+
+    engine = RuleEngine()
+    try:
+        won = run_bot(client, engine, start_game=False, poll_interval=0.2,
+                      stream_delay=2.0)
+    except Exception as e:
+        print(f"\n  FAIL (game 1): Bot crashed with {type(e).__name__}: {e}")
+        sys.exit(1)
+
+    # run_bot may return False even on a real win: _check_victory requires
+    # ante 9+ to guard against Hieroglyph false positives. In fast mode the
+    # game can go to GAME_OVER before ante advances. That's fine — this test
+    # is about server survival, not victory detection accuracy.
+    print(f"\n  Game 1 result: won={won} (victory detection may lag — OK)")
+
+    # ---- Check server health after win ----
+    print("\n--- POST-WIN: Checking server health ---")
+    time.sleep(1)  # brief pause for any in-flight transitions
+
+    try:
+        health = client.call("health")
+        print(f"  Server health: OK")
+    except Exception as e:
+        print(f"\n  FAIL: Server dead after win — {type(e).__name__}: {e}")
+        print("  This is the game_103 bug: cash_out.lua doesn't handle")
+        print("  GAME_OVER transition after winning in endless mode.")
+        print("=" * 60)
+        sys.exit(1)
+
+    # ---- Game 2: start a fresh game ----
+    print("\n--- GAME 2: Starting fresh game ---")
+    try:
+        client.call("menu")
+    except APIError:
+        pass
+    time.sleep(0.5)
+
+    try:
+        state = client.call("start", {
+            "deck": "RED", "stake": "WHITE", "seed": "MULTIGAME2",
+        })
+        print(f"  Game 2 started: state={state.get('state')}")
+    except Exception as e:
+        print(f"\n  FAIL (game 2): Could not start new game — {type(e).__name__}: {e}")
+        sys.exit(1)
+
+    # Verify we're in a playable state
+    for _ in range(20):
+        state = client.call("gamestate")
+        if state.get("state") in ("SELECTING_HAND", "BLIND_SELECT"):
+            break
+        time.sleep(0.3)
+
+    gs = state.get("state", "?")
+    if gs in ("SELECTING_HAND", "BLIND_SELECT"):
+        print(f"  Game 2 playable: state={gs}")
+    else:
+        print(f"\n  FAIL: Game 2 stuck in state={gs}")
+        sys.exit(1)
+
+    print("\n" + "=" * 60)
+    print("PASS: Server survived win screen, game 2 started successfully")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_win_multigame_bug.py
+++ b/tests/integration/test_win_multigame_bug.py
@@ -29,8 +29,8 @@ from balatrobot.cli.client import BalatroClient, APIError
 from balatro_bot.engine import RuleEngine
 from balatro_bot.bot import run_bot, setup_logging
 from harness import (
-    start_server, stop_server, setup_game, inject_god_mode_complex,
-    advance_to_boss_select, get_boss_name, wait_for_state,
+    start_server, stop_server, setup_god_mode_ante8,
+    wait_for_state,
     TEST_PORT, _check_port,
 )
 
@@ -69,31 +69,6 @@ def main():
             stop_server(server_proc)
 
 
-def _setup_god_mode_ante8(client: BalatroClient, seed: str) -> dict:
-    """Cheat to ante 8 boss, inject god-mode jokers, let bot play with 4 hands."""
-    setup_game(client, seed=seed)
-    advance_to_boss_select(client, target_ante=8)
-
-    state = client.call("gamestate")
-    print(f"\n  Ante 8 boss: {get_boss_name(state)}")
-
-    if state.get("state") == "BLIND_SELECT":
-        client.call("select")
-        time.sleep(0.5)
-        state = wait_for_state(client, {"SELECTING_HAND"})
-
-    # Sell existing jokers to make room for god-mode ones
-    joker_count = state.get("jokers", {}).get("count", 0)
-    for _ in range(joker_count):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    inject_god_mode_complex(client)
-    return client.call("gamestate")
-
-
 def _run_test(client: BalatroClient):
     print("\n" + "=" * 60)
     print("TEST: Server survives win screen for multi-game loop")
@@ -101,7 +76,7 @@ def _run_test(client: BalatroClient):
 
     # ---- Game 1: win at ante 8 ----
     print("\n--- GAME 1: Win at ante 8 ---")
-    _setup_god_mode_ante8(client, seed="MULTIGAME1")
+    setup_god_mode_ante8(client, seed="MULTIGAME1")
 
     engine = RuleEngine()
     try:

--- a/tests/integration/test_win_multigame_fix.py
+++ b/tests/integration/test_win_multigame_fix.py
@@ -1,0 +1,241 @@
+"""Integration test: verifies the cash_out GAME_OVER fix.
+
+Same multi-game scenario as test_win_multigame_bug.py, but patches
+cash_out.lua BEFORE starting the server so that:
+  1. BB_GAMESTATE.on_game_over = send_response is set before cash_out
+  2. The inner condition event also checks for GAME_OVER (not just SHOP)
+
+This mirrors what play.lua already does — the fix is adding the same
+GAME_OVER handling to cash_out.lua.
+
+MUST run headed — the win-screen hang only triggers with the real UI.
+
+Usage:
+    python test_win_multigame_fix.py [--port PORT]
+"""
+
+import argparse
+import logging
+import os
+import re
+import shutil
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "support"))
+
+from balatrobot.cli.client import BalatroClient, APIError
+from balatro_bot.engine import RuleEngine
+from balatro_bot.bot import run_bot, setup_logging
+from balatro_bot.config import SupervisorConfig
+from harness import (
+    start_server, stop_server, setup_game, inject_god_mode_complex,
+    advance_to_boss_select, get_boss_name, wait_for_state,
+    TEST_PORT, _check_port,
+)
+
+_cfg = SupervisorConfig()
+
+# Path to the installed cash_out.lua
+CASH_OUT_LUA = os.path.join(
+    os.environ.get("APPDATA", ""),
+    "Balatro", "Mods", "balatrobot-1.4.1",
+    "src", "lua", "endpoints", "cash_out.lua",
+)
+
+
+def patch_cash_out():
+    """Patch cash_out.lua to handle GAME_OVER (like play.lua does).
+
+    Returns the original content for restore, or None if patch not needed.
+    """
+    if not os.path.exists(CASH_OUT_LUA):
+        print(f"  WARNING: {CASH_OUT_LUA} not found, skipping patch")
+        return None
+
+    with open(CASH_OUT_LUA, "r") as f:
+        original = f.read()
+
+    if "on_game_over" in original:
+        print("  cash_out.lua already has on_game_over handling, skipping patch")
+        return None
+
+    # Patch 1: Add on_game_over callback before G.FUNCS.cash_out call
+    patched = original.replace(
+        '        sendDebugMessage("cash_out() - scoring complete, triggering cash out", "BB.ENDPOINTS")\n'
+        '        G.FUNCS.cash_out({ config = {} })',
+
+        '        sendDebugMessage("cash_out() - scoring complete, triggering cash out", "BB.ENDPOINTS")\n'
+        '        -- [FIX] Handle GAME_OVER transition (won state in endless mode)\n'
+        '        BB_GAMESTATE.on_game_over = send_response\n'
+        '        G.FUNCS.cash_out({ config = {} })',
+    )
+
+    # Patch 2: Add GAME_OVER check in inner condition event
+    patched = patched.replace(
+        '            local done = false\n'
+        '            if G.STATE == G.STATES.SHOP and G.STATE_COMPLETE then',
+
+        '            local done = false\n'
+        '            -- [FIX] If game ended (won state), deliver response via this check\n'
+        '            if G.STATE == G.STATES.GAME_OVER then\n'
+        '              send_response(BB_GAMESTATE.get_gamestate())\n'
+        '              return true\n'
+        '            end\n'
+        '            if G.STATE == G.STATES.SHOP and G.STATE_COMPLETE then',
+    )
+
+    if patched == original:
+        print("  WARNING: Patch markers not found in cash_out.lua — file may have changed")
+        return None
+
+    with open(CASH_OUT_LUA, "w") as f:
+        f.write(patched)
+
+    print("  Patched cash_out.lua with GAME_OVER handling")
+    return original
+
+
+def restore_cash_out(original_content):
+    """Restore cash_out.lua to its original content."""
+    if original_content is None:
+        return
+    with open(CASH_OUT_LUA, "w") as f:
+        f.write(original_content)
+    print("  Restored original cash_out.lua")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test: cash_out GAME_OVER fix — server survives win screen"
+    )
+    parser.add_argument("--port", type=int, default=TEST_PORT)
+    args = parser.parse_args()
+
+    # Match stream mode logging exactly — setup_logging with stream_file
+    log_dir = os.path.join(os.path.dirname(__file__), "..", "..", "logs", "test_multigame_fix")
+    os.makedirs(log_dir, exist_ok=True)
+    setup_logging(
+        log_file=os.path.join(log_dir, "game.log"),
+        wins_file=os.path.join(log_dir, "wins.txt"),
+        scoring_file=os.path.join(log_dir, "scoring.log"),
+        stream_file=os.path.join(log_dir, "stream.log"),
+    )
+
+    # Patch cash_out.lua BEFORE starting the server
+    original_lua = patch_cash_out()
+
+    server_proc = None
+    try:
+        if _check_port(args.port):
+            print(f"  Server already running on port {args.port}")
+            print("  WARNING: server was started before patch — results may not reflect fix")
+            client = BalatroClient(port=args.port)
+        else:
+            # fast=False to match stream mode — must reproduce the same conditions
+            server_proc = start_server(port=args.port, headless=False, fast=False)
+            client = BalatroClient(port=args.port)
+
+        _run_test(client)
+    finally:
+        if server_proc:
+            stop_server(server_proc)
+        restore_cash_out(original_lua)
+
+
+def _setup_god_mode_ante8(client: BalatroClient, seed: str) -> dict:
+    """Cheat to ante 8 boss, inject god-mode jokers, let bot play with 4 hands."""
+    setup_game(client, seed=seed)
+    advance_to_boss_select(client, target_ante=8)
+
+    state = client.call("gamestate")
+    print(f"\n  Ante 8 boss: {get_boss_name(state)}")
+
+    if state.get("state") == "BLIND_SELECT":
+        client.call("select")
+        time.sleep(0.5)
+        state = wait_for_state(client, {"SELECTING_HAND"})
+
+    # Sell existing jokers to make room for god-mode ones
+    joker_count = state.get("jokers", {}).get("count", 0)
+    for _ in range(joker_count):
+        try:
+            client.call("sell", {"joker": 0})
+        except APIError:
+            pass
+
+    inject_god_mode_complex(client)
+    return client.call("gamestate")
+
+
+def _run_test(client: BalatroClient):
+    print("\n" + "=" * 60)
+    print("TEST: cash_out GAME_OVER fix — multi-game win survival")
+    print("=" * 60)
+
+    # ---- Game 1: win at ante 8 ----
+    print("\n--- GAME 1: Win at ante 8 ---")
+    _setup_god_mode_ante8(client, seed="FIXTEST1")
+
+    engine = RuleEngine()
+    try:
+        won = run_bot(client, engine, start_game=False, poll_interval=0.2,
+                      stream_delay=2.0)
+    except Exception as e:
+        print(f"\n  FAIL (game 1): Bot crashed with {type(e).__name__}: {e}")
+        sys.exit(1)
+
+    # run_bot may return False even on a real win — see test_win_multigame_bug.py
+    print(f"\n  Game 1 result: won={won} (victory detection may lag — OK)")
+
+    # ---- Check server health after win ----
+    print("\n--- POST-WIN: Checking server health ---")
+    time.sleep(1)
+
+    try:
+        health = client.call("health")
+        print(f"  Server health: OK")
+    except Exception as e:
+        print(f"\n  FAIL: Server dead after win even WITH fix — {type(e).__name__}: {e}")
+        print("  The GAME_OVER handling patch didn't prevent the crash.")
+        print("=" * 60)
+        sys.exit(1)
+
+    # ---- Game 2: start a fresh game ----
+    print("\n--- GAME 2: Starting fresh game ---")
+    try:
+        client.call("menu")
+    except APIError:
+        pass
+    time.sleep(0.5)
+
+    try:
+        state = client.call("start", {
+            "deck": "RED", "stake": "WHITE", "seed": "FIXTEST2",
+        })
+        print(f"  Game 2 started: state={state.get('state')}")
+    except Exception as e:
+        print(f"\n  FAIL (game 2): Could not start new game — {type(e).__name__}: {e}")
+        sys.exit(1)
+
+    for _ in range(20):
+        state = client.call("gamestate")
+        if state.get("state") in ("SELECTING_HAND", "BLIND_SELECT"):
+            break
+        time.sleep(0.3)
+
+    gs = state.get("state", "?")
+    if gs in ("SELECTING_HAND", "BLIND_SELECT"):
+        print(f"  Game 2 playable: state={gs}")
+    else:
+        print(f"\n  FAIL: Game 2 stuck in state={gs}")
+        sys.exit(1)
+
+    print("\n" + "=" * 60)
+    print("PASS: Fix works — server survived win screen, game 2 started")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_win_multigame_fix.py
+++ b/tests/integration/test_win_multigame_fix.py
@@ -30,8 +30,8 @@ from balatro_bot.engine import RuleEngine
 from balatro_bot.bot import run_bot, setup_logging
 from balatro_bot.config import SupervisorConfig
 from harness import (
-    start_server, stop_server, setup_game, inject_god_mode_complex,
-    advance_to_boss_select, get_boss_name, wait_for_state,
+    start_server, stop_server, setup_god_mode_ante8,
+    wait_for_state,
     TEST_PORT, _check_port,
 )
 
@@ -144,31 +144,6 @@ def main():
         restore_cash_out(original_lua)
 
 
-def _setup_god_mode_ante8(client: BalatroClient, seed: str) -> dict:
-    """Cheat to ante 8 boss, inject god-mode jokers, let bot play with 4 hands."""
-    setup_game(client, seed=seed)
-    advance_to_boss_select(client, target_ante=8)
-
-    state = client.call("gamestate")
-    print(f"\n  Ante 8 boss: {get_boss_name(state)}")
-
-    if state.get("state") == "BLIND_SELECT":
-        client.call("select")
-        time.sleep(0.5)
-        state = wait_for_state(client, {"SELECTING_HAND"})
-
-    # Sell existing jokers to make room for god-mode ones
-    joker_count = state.get("jokers", {}).get("count", 0)
-    for _ in range(joker_count):
-        try:
-            client.call("sell", {"joker": 0})
-        except APIError:
-            pass
-
-    inject_god_mode_complex(client)
-    return client.call("gamestate")
-
-
 def _run_test(client: BalatroClient):
     print("\n" + "=" * 60)
     print("TEST: cash_out GAME_OVER fix — multi-game win survival")
@@ -176,7 +151,7 @@ def _run_test(client: BalatroClient):
 
     # ---- Game 1: win at ante 8 ----
     print("\n--- GAME 1: Win at ante 8 ---")
-    _setup_god_mode_ante8(client, seed="FIXTEST1")
+    setup_god_mode_ante8(client, seed="FIXTEST1")
 
     engine = RuleEngine()
     try:

--- a/tests/test_chase.py
+++ b/tests/test_chase.py
@@ -1,0 +1,556 @@
+"""Tests for chase strategy generation and extended draw quality functions.
+
+Covers:
+- generate_chases() producing all hand-type transitions
+- New draw quality functions (pair, full house, four of a kind, etc.)
+- chase_score() using real hand levels
+- cards_not_in() sort priority rework (debuff as tiebreaker)
+- flush_draw_quality debuff handling
+"""
+
+from balatro_bot.domain.scoring.chase import generate_chases
+from balatro_bot.domain.scoring.draws import (
+    pair_draw_quality,
+    full_house_draw_quality,
+    full_house_draw_quality_tight,
+    four_kind_draw_quality,
+    five_kind_draw_quality,
+    straight_flush_draw_quality,
+    flush_draw_quality,
+    flush_draw_quality_loose,
+    two_pair_draw_quality,
+    two_pair_draw_quality_tight,
+    three_kind_draw_quality,
+)
+from balatro_bot.domain.scoring.search import (
+    best_hand,
+    cards_not_in,
+    discard_candidates,
+)
+from tests.conftest import card, debuffed_card
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _deck(suits="HDCS", ranks="23456789TJQKA", exclude=None):
+    exclude = exclude or set()
+    return [card(r, s) for s in suits for r in ranks if (r, s) not in exclude]
+
+
+def _deck_excluding_hand(hand):
+    """Build a standard deck minus cards in hand."""
+    hand_keys = {(c.value.rank, c.value.suit) for c in hand}
+    return _deck(exclude=hand_keys)
+
+
+# ---------------------------------------------------------------------------
+# pair_draw_quality
+# ---------------------------------------------------------------------------
+
+class TestPairDrawQuality:
+    def test_finds_pair_from_singleton(self):
+        hand = [card("A", "H"), card("K", "S"), card("Q", "D")]
+        deck = _deck_excluding_hand(hand)
+        result = pair_draw_quality(hand, deck)
+        assert result is not None
+        indices, prob = result
+        assert len(indices) == 1
+        assert prob > 0
+
+    def test_prefers_rank_with_most_deck_copies(self):
+        hand = [card("A", "H"), card("3", "S")]
+        # Deck has 3 Aces left but only 3 Threes left — equal, so A wins by rank
+        deck = _deck_excluding_hand(hand)
+        result = pair_draw_quality(hand, deck)
+        assert result is not None
+        indices, _ = result
+        assert indices == [0]  # Ace index
+
+    def test_returns_none_when_already_have_pair(self):
+        hand = [card("A", "H"), card("A", "S"), card("3", "D")]
+        deck = _deck_excluding_hand(hand)
+        result = pair_draw_quality(hand, deck)
+        # Singletons only — 3 is the only singleton
+        assert result is not None
+        indices, _ = result
+        assert indices == [2]  # Only the 3
+
+    def test_respects_rank_affinity(self):
+        hand = [card("A", "H"), card("3", "S")]
+        deck = _deck_excluding_hand(hand)
+        # Strongly prefer 3s
+        result = pair_draw_quality(hand, deck, rank_affinity={"3": 5.0, "A": 0.0})
+        assert result is not None
+        indices, _ = result
+        # Both have 3 copies in deck but 3 has higher affinity
+        assert indices == [1]
+
+
+# ---------------------------------------------------------------------------
+# full_house_draw_quality
+# ---------------------------------------------------------------------------
+
+class TestFullHouseDrawQuality:
+    def test_from_three_of_a_kind(self):
+        hand = [card("K", "H"), card("K", "S"), card("K", "D"), card("5", "C"), card("2", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = full_house_draw_quality(hand, deck)
+        assert result is not None
+        indices, prob = result
+        # Should keep the three Kings
+        assert set(indices) == {0, 1, 2}
+        assert prob > 0
+
+    def test_from_two_pair(self):
+        hand = [card("K", "H"), card("K", "S"), card("Q", "D"), card("Q", "C"), card("2", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = full_house_draw_quality(hand, deck)
+        assert result is not None
+        indices, prob = result
+        assert len(indices) == 4  # Both pairs
+        assert prob > 0
+
+    def test_returns_none_without_trips_or_two_pair(self):
+        hand = [card("A", "H"), card("K", "S"), card("Q", "D"), card("J", "C"), card("T", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = full_house_draw_quality(hand, deck)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# four_kind_draw_quality
+# ---------------------------------------------------------------------------
+
+class TestFourKindDrawQuality:
+    def test_from_three_of_a_kind(self):
+        hand = [card("A", "H"), card("A", "S"), card("A", "D"), card("5", "C"), card("2", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = four_kind_draw_quality(hand, deck)
+        assert result is not None
+        indices, prob = result
+        assert set(indices) == {0, 1, 2}
+        # 1 Ace left in 47-card deck, drawing 5 cards
+        assert 0 < prob < 1
+
+    def test_returns_none_without_trips(self):
+        hand = [card("A", "H"), card("A", "S"), card("K", "D"), card("5", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = four_kind_draw_quality(hand, deck)
+        assert result is None
+
+    def test_returns_none_when_no_fourth_in_deck(self):
+        hand = [card("A", "H"), card("A", "S"), card("A", "D")]
+        # Remove the 4th Ace from deck
+        deck = [c for c in _deck_excluding_hand(hand) if c.value.rank != "A"]
+        result = four_kind_draw_quality(hand, deck)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# five_kind_draw_quality
+# ---------------------------------------------------------------------------
+
+class TestFiveKindDrawQuality:
+    def test_returns_none_without_quads(self):
+        hand = [card("A", "H"), card("A", "S"), card("A", "D")]
+        deck = _deck_excluding_hand(hand)
+        result = five_kind_draw_quality(hand, deck)
+        assert result is None
+
+    def test_returns_none_when_no_fifth_in_deck(self):
+        hand = [card("A", "H"), card("A", "S"), card("A", "D"), card("A", "C")]
+        deck = _deck_excluding_hand(hand)  # No 5th ace possible
+        result = five_kind_draw_quality(hand, deck)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# straight_flush_draw_quality
+# ---------------------------------------------------------------------------
+
+class TestStraightFlushDrawQuality:
+    def test_finds_4_suited_sequential(self):
+        hand = [card("T", "H"), card("J", "H"), card("Q", "H"), card("K", "H"), card("2", "S")]
+        deck = _deck_excluding_hand(hand)
+        result = straight_flush_draw_quality(hand, deck)
+        assert result is not None
+        indices, prob = result
+        assert len(indices) == 4
+        # All four hearts should be kept
+        assert set(indices) <= {0, 1, 2, 3}
+        assert prob > 0
+
+    def test_returns_none_when_not_4_suited_sequential(self):
+        hand = [card("T", "H"), card("J", "S"), card("Q", "H"), card("K", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = straight_flush_draw_quality(hand, deck)
+        assert result is None
+
+    def test_returns_none_with_4_suited_but_not_sequential(self):
+        hand = [card("2", "H"), card("5", "H"), card("9", "H"), card("K", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = straight_flush_draw_quality(hand, deck)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# generate_chases — comprehensive strategy generation
+# ---------------------------------------------------------------------------
+
+class TestGenerateChases:
+    def test_always_includes_keep_best_hand(self):
+        hand = [card("A", "H"), card("K", "S"), card("Q", "D"), card("J", "C"), card("T", "H")]
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh)
+        names = [s[0] for s in strategies]
+        assert bh.hand_name in names
+
+    def test_includes_flush_chase_when_4_suited(self):
+        hand = [card("A", "H"), card("K", "H"), card("Q", "H"), card("J", "H"),
+                card("2", "S"), card("3", "C"), card("4", "D"), card("5", "S")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        names = [s[0] for s in strategies]
+        assert "Flush" in names
+
+    def test_includes_full_house_chase_from_trips(self):
+        hand = [card("K", "H"), card("K", "S"), card("K", "D"),
+                card("5", "C"), card("2", "H"), card("7", "S"), card("9", "D"), card("J", "C")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        names = [s[0] for s in strategies]
+        assert "Full House" in names
+
+    def test_includes_four_kind_chase_from_trips(self):
+        hand = [card("A", "H"), card("A", "S"), card("A", "D"),
+                card("5", "C"), card("2", "H"), card("7", "S"), card("9", "D"), card("J", "C")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        names = [s[0] for s in strategies]
+        assert "Four of a Kind" in names
+
+    def test_includes_pair_chase_from_high_card(self):
+        hand = [card("A", "H"), card("K", "S"), card("Q", "D"),
+                card("J", "C"), card("9", "H"), card("7", "S"), card("5", "D"), card("3", "C")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        # Current best is High Card — should chase Pair
+        assert bh.hand_name == "High Card"
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        names = [s[0] for s in strategies]
+        assert "Pair" in names
+
+    def test_respects_required_hand_filter(self):
+        hand = [card("A", "H"), card("K", "H"), card("Q", "H"), card("J", "H"),
+                card("2", "S"), card("3", "C"), card("4", "D"), card("5", "S")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck, required_hand="Flush")
+        names = [s[0] for s in strategies]
+        assert "Flush" in names
+        # Other chase types filtered out (except redraw)
+        assert all(n in ("Flush", "redraw") for n in names)
+
+    def test_includes_straight_flush_chase(self):
+        hand = [card("T", "H"), card("J", "H"), card("Q", "H"), card("K", "H"),
+                card("2", "S"), card("3", "C"), card("4", "D"), card("5", "S")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        names = [s[0] for s in strategies]
+        assert "Straight Flush" in names
+
+
+# ---------------------------------------------------------------------------
+# chase_score with hand levels
+# ---------------------------------------------------------------------------
+
+class TestChaseScoreUsesHandLevels:
+    def test_keep_leveled_pair_ranks_above_base_flush_chase(self):
+        """Keep leveled-Pair strategy should outrank a Flush chase at base levels.
+
+        Level-5 Pair: 70 chips × 6 mult × 1.0 prob = 420
+        Base Flush:   35 chips × 4 mult × ~0.5 prob ≈ 70
+        """
+        # 2 spade Kings for a pair, 3 hearts for a flush draw (not enough for flush)
+        hand = [card("K", "S"), card("K", "C"),
+                card("A", "H"), card("9", "H"), card("5", "H"),
+                card("7", "D"), card("3", "D"), card("2", "D")]
+        deck = _deck_excluding_hand(hand)
+
+        hand_levels = {
+            "Pair": {"chips": 70, "mult": 6, "level": 5},
+            "Flush": {"chips": 35, "mult": 4, "level": 1},
+            "High Card": {"chips": 5, "mult": 1, "level": 1},
+            "Straight": {"chips": 30, "mult": 4, "level": 1},
+            "Two Pair": {"chips": 20, "mult": 2, "level": 1},
+            "Three of a Kind": {"chips": 30, "mult": 3, "level": 1},
+            "Full House": {"chips": 40, "mult": 4, "level": 1},
+            "Four of a Kind": {"chips": 60, "mult": 7, "level": 1},
+        }
+
+        results = discard_candidates(
+            hand, hand_levels=hand_levels, deck_cards=deck,
+        )
+        chase_names = [r.chase_hand for r in results]
+        # Keep Pair (leveled: 420) should rank above any base-level chase
+        assert chase_names[0] == "Pair", f"Expected Pair first, got {chase_names}"
+
+
+# ---------------------------------------------------------------------------
+# cards_not_in sort order — debuff as tiebreaker
+# ---------------------------------------------------------------------------
+
+class TestCardsNotInDebuffPriority:
+    def test_debuffed_card_with_affinity_survives_over_junk(self):
+        """A debuffed King with high rank affinity should survive over a non-debuffed 2."""
+        hand = [
+            card("A", "H"),         # 0 — in keep
+            debuffed_card("K", "S"),  # 1 — debuffed but high rank
+            card("2", "D"),         # 2 — junk
+        ]
+        keep = {0}
+        rank_aff = {"K": 2.0, "A": 1.0, "2": -1.0}
+        result = cards_not_in(hand, keep, rank_affinity=rank_aff)
+        # 2 should be discarded first (low affinity), K second (high affinity despite debuff)
+        assert result == [2, 1]
+
+    def test_debuffed_junk_still_discarded_first(self):
+        """A debuffed 2 with no affinity should still be discarded before a non-debuffed 3."""
+        hand = [
+            card("A", "H"),         # 0 — in keep
+            debuffed_card("2", "S"),  # 1 — debuffed junk
+            card("3", "D"),         # 2 — also junk but not debuffed
+        ]
+        keep = {0}
+        result = cards_not_in(hand, keep)
+        # Both are junk, debuff breaks the tie — 2 goes first
+        assert result[0] == 1
+
+    def test_scoring_suit_still_primary(self):
+        """Scoring suit boss restriction should still be the top priority."""
+        hand = [
+            card("A", "H"),         # 0 — in keep
+            card("K", "H"),         # 1 — scoring suit (H)
+            debuffed_card("Q", "S"),  # 2 — debuffed, off-suit
+        ]
+        keep = {0}
+        result = cards_not_in(hand, keep, scoring_suit="H")
+        # Off-suit Q goes first despite being debuffed (scoring_suit protects K♥)
+        assert result[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# flush_draw_quality — debuff deprioritization
+# ---------------------------------------------------------------------------
+
+class TestFlushDrawQualityDebuff:
+    def test_prefers_non_debuffed_card_in_flush(self):
+        """When picking 4 from 5 suited cards, non-debuffed should be preferred."""
+        hand = [
+            card("A", "H"),          # 0
+            debuffed_card("K", "H"), # 1 — debuffed
+            card("Q", "H"),          # 2
+            card("J", "H"),          # 3
+            card("T", "H"),          # 4
+        ]
+        deck = _deck_excluding_hand(hand)
+        result = flush_draw_quality(hand, deck)
+        assert result is not None
+        indices, _, _ = result
+        # Debuffed K♥ should be dropped in favor of non-debuffed T♥
+        assert 1 not in indices, "Debuffed K♥ should not be in the flush keep set"
+        assert 4 in indices, "Non-debuffed T♥ should be kept"
+
+
+# ---------------------------------------------------------------------------
+# two_pair_draw_quality — probability no longer overcounts
+# ---------------------------------------------------------------------------
+
+class TestTwoPairProbability:
+    def test_probability_never_exceeds_one(self):
+        """With many viable ranks, probability should use inclusion-exclusion, not raw sum."""
+        hand = [card("A", "H"), card("A", "S"),
+                card("K", "D"), card("Q", "C"), card("J", "H"),
+                card("T", "S"), card("9", "D"), card("8", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = two_pair_draw_quality(hand, deck)
+        assert result is not None
+        _, prob = result
+        assert 0 < prob <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tight + loose keep-set variants
+# ---------------------------------------------------------------------------
+
+class TestTwoPairTightVariant:
+    def test_keeps_pair_plus_singleton(self):
+        """Tight variant keeps pair + best singleton."""
+        hand = [card("A", "H"), card("A", "S"),
+                card("K", "D"), card("Q", "C"), card("5", "H")]
+        deck = _deck_excluding_hand(hand)
+        result = two_pair_draw_quality_tight(hand, deck)
+        assert result is not None
+        indices, prob = result
+        assert len(indices) == 3  # pair (2) + singleton (1)
+        assert 0 in indices and 1 in indices  # Aces
+        assert prob > 0
+
+    def test_prefers_singleton_with_most_deck_copies(self):
+        """Should pick the singleton rank with more copies in deck."""
+        hand = [card("A", "H"), card("A", "S"),
+                card("K", "D"), card("3", "C")]
+        # Remove some Kings from deck to make 3 more available
+        deck = [c for c in _deck_excluding_hand(hand) if c.value.rank != "K"]
+        result = two_pair_draw_quality_tight(hand, deck)
+        assert result is not None
+        indices, _ = result
+        assert 3 in indices  # 3 chosen over K (more copies in deck)
+
+    def test_returns_none_without_singletons(self):
+        """If all non-pair cards are also paired, tight variant can't apply."""
+        hand = [card("A", "H"), card("A", "S"),
+                card("K", "D"), card("K", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = two_pair_draw_quality_tight(hand, deck)
+        assert result is None
+
+    def test_fewer_draws_than_loose(self):
+        """Tight keeps 3 cards (pair+1), loose keeps 2 (pair only)."""
+        hand = [card("A", "H"), card("A", "S"),
+                card("K", "D"), card("Q", "C"), card("J", "H"),
+                card("T", "S"), card("9", "D"), card("8", "C")]
+        deck = _deck_excluding_hand(hand)
+        loose = two_pair_draw_quality(hand, deck)
+        tight = two_pair_draw_quality_tight(hand, deck)
+        assert loose is not None and tight is not None
+        assert len(tight[0]) > len(loose[0])  # tight keeps more cards
+
+
+class TestFlushLooseVariant:
+    def test_activates_with_3_suited(self):
+        """Loose flush should work with exactly 3 suited cards."""
+        hand = [card("A", "H"), card("K", "H"), card("Q", "H"),
+                card("5", "S"), card("3", "C"), card("2", "D"),
+                card("7", "S"), card("9", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = flush_draw_quality_loose(hand, deck)
+        assert result is not None
+        indices, prob, suit = result
+        assert len(indices) == 3
+        assert suit == "H"
+        assert prob > 0
+
+    def test_does_not_activate_with_4_suited(self):
+        """When 4+ suited exist, loose should not fire (tight dominates)."""
+        hand = [card("A", "H"), card("K", "H"), card("Q", "H"), card("J", "H"),
+                card("5", "S"), card("3", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = flush_draw_quality_loose(hand, deck)
+        assert result is None
+
+    def test_probability_lower_than_tight(self):
+        """Needing 2 of suit should have lower probability than needing 1.
+
+        Comparing: 3 hearts (loose, need 2) vs hypothetical 4 hearts (tight, need 1).
+        We test indirectly by checking loose prob < 1.0 and is reasonable.
+        """
+        hand = [card("A", "H"), card("K", "H"), card("Q", "H"),
+                card("5", "S"), card("3", "C"), card("2", "D"),
+                card("7", "S"), card("9", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = flush_draw_quality_loose(hand, deck)
+        assert result is not None
+        _, prob, _ = result
+        assert 0 < prob < 0.95  # Needing 2 cards is hard
+
+
+class TestFullHouseTightVariant:
+    def test_keeps_trips_plus_singleton(self):
+        """Tight variant keeps trips + best singleton."""
+        hand = [card("K", "H"), card("K", "S"), card("K", "D"),
+                card("5", "C"), card("2", "H"), card("7", "S"), card("9", "D")]
+        deck = _deck_excluding_hand(hand)
+        result = full_house_draw_quality_tight(hand, deck)
+        assert result is not None
+        indices, prob = result
+        assert len(indices) == 4  # trips (3) + singleton (1)
+        assert {0, 1, 2} <= set(indices)  # Kings kept
+        assert prob > 0
+
+    def test_returns_none_without_trips(self):
+        """No trips = no tight full house chase."""
+        hand = [card("A", "H"), card("K", "S"), card("Q", "D"), card("J", "C")]
+        deck = _deck_excluding_hand(hand)
+        result = full_house_draw_quality_tight(hand, deck)
+        assert result is None
+
+    def test_returns_none_without_companions(self):
+        """If hand is only trips with no other cards, tight can't apply."""
+        hand = [card("A", "H"), card("A", "S"), card("A", "D")]
+        deck = _deck_excluding_hand(hand)
+        result = full_house_draw_quality_tight(hand, deck)
+        assert result is None
+
+    def test_prefers_companion_with_most_copies(self):
+        """Should pick singleton rank with more copies in deck."""
+        hand = [card("K", "H"), card("K", "S"), card("K", "D"),
+                card("5", "C"), card("2", "H")]
+        # Remove all but 1 Five from deck, leave 3 Twos
+        deck = [c for c in _deck_excluding_hand(hand)
+                if not (c.value.rank == "5")]
+        result = full_house_draw_quality_tight(hand, deck)
+        assert result is not None
+        indices, _ = result
+        # 2 should be chosen over 5 (more copies in deck)
+        assert 4 in indices
+
+
+class TestGenerateChasesVariants:
+    def test_two_pair_generates_both_variants(self):
+        """Two Pair chase should produce both loose and tight strategies."""
+        # Pair of Aces + scattered ranks (no straight potential)
+        hand = [card("A", "H"), card("A", "S"),
+                card("5", "D"), card("3", "C"), card("9", "H"),
+                card("7", "S"), card("2", "D"), card("J", "C")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        assert bh.hand_name == "Pair"
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        tp_strategies = [s for s in strategies if s[0] == "Two Pair"]
+        assert len(tp_strategies) >= 2, f"Expected 2+ Two Pair strategies, got {len(tp_strategies)}"
+        reasons = [s[3] for s in tp_strategies]
+        assert any("loose" in r for r in reasons)
+        assert any("tight" in r for r in reasons)
+
+    def test_flush_generates_loose_with_3_suited(self):
+        """Flush loose should appear when only 3 suited cards exist."""
+        hand = [card("A", "H"), card("K", "H"), card("Q", "H"),
+                card("5", "S"), card("3", "C"), card("2", "D"),
+                card("7", "S"), card("9", "C")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        flush_strategies = [s for s in strategies if s[0] == "Flush"]
+        reasons = [s[3] for s in flush_strategies]
+        assert any("loose" in r for r in reasons), f"Expected Flush loose, got {reasons}"
+
+    def test_full_house_generates_both_from_trips(self):
+        """Full House should produce both loose and tight from trips."""
+        hand = [card("K", "H"), card("K", "S"), card("K", "D"),
+                card("5", "C"), card("2", "H"), card("7", "S"),
+                card("9", "D"), card("J", "C")]
+        deck = _deck_excluding_hand(hand)
+        bh = best_hand(hand)
+        strategies = generate_chases(hand, bh, deck_cards=deck)
+        fh_strategies = [s for s in strategies if s[0] == "Full House"]
+        assert len(fh_strategies) >= 2, f"Expected 2+ FH strategies, got {len(fh_strategies)}"
+        reasons = [s[3] for s in fh_strategies]
+        assert any("loose" in r for r in reasons)
+        assert any("tight" in r for r in reasons)

--- a/tests/test_deck_profile.py
+++ b/tests/test_deck_profile.py
@@ -1,0 +1,192 @@
+"""Tests for DeckProfile — deck composition tracking."""
+
+from tests.conftest import card, stone_card, wild_card
+from balatro_bot.domain.models.deck_profile import DeckProfile
+
+
+RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"]
+SUITS = ["H", "D", "C", "S"]
+
+
+def _standard_52() -> list:
+    """Build a standard 52-card deck."""
+    return [card(r, s) for s in SUITS for r in RANKS]
+
+
+class TestBasicCounts:
+    def test_standard_deck_total(self):
+        dp = DeckProfile.from_cards(_standard_52())
+        assert dp.total_cards == 52
+
+    def test_standard_deck_suit_counts(self):
+        dp = DeckProfile.from_cards(_standard_52())
+        for s in SUITS:
+            assert dp.suit_counts[s] == 13
+
+    def test_standard_deck_rank_counts(self):
+        dp = DeckProfile.from_cards(_standard_52())
+        for r in RANKS:
+            assert dp.rank_counts[r] == 4
+
+    def test_no_enhancements_in_standard_deck(self):
+        dp = DeckProfile.from_cards(_standard_52())
+        assert dp.enhanced_card_count == 0
+        assert dp.enhancement_counts == {}
+
+    def test_empty_deck(self):
+        dp = DeckProfile.from_cards([])
+        assert dp.total_cards == 0
+        assert dp.suit_counts == {}
+        assert dp.rank_counts == {}
+
+
+class TestEnhancements:
+    def test_enhancement_counts(self):
+        cards = [
+            card("A", "H", enhancement="STEEL"),
+            card("K", "H", enhancement="STEEL"),
+            card("Q", "D", enhancement="LUCKY"),
+            card("J", "C"),  # no enhancement
+        ]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancement_counts["STEEL"] == 2
+        assert dp.enhancement_counts["LUCKY"] == 1
+        assert dp.enhanced_card_count == 3
+
+    def test_enhancements_by_suit(self):
+        cards = [
+            card("A", "H", enhancement="STEEL"),
+            card("K", "H", enhancement="STEEL"),
+            card("Q", "D", enhancement="STEEL"),
+            card("J", "C", enhancement="LUCKY"),
+        ]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancements_by_suit["H"]["STEEL"] == 2
+        assert dp.enhancements_by_suit["D"]["STEEL"] == 1
+        assert dp.enhancements_by_suit["C"]["LUCKY"] == 1
+        assert "S" not in dp.enhancements_by_suit
+
+    def test_enhancements_by_rank(self):
+        cards = [
+            card("K", "H", enhancement="STEEL"),
+            card("K", "D", enhancement="STEEL"),
+            card("Q", "H", enhancement="LUCKY"),
+        ]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancements_by_rank["K"]["STEEL"] == 2
+        assert dp.enhancements_by_rank["Q"]["LUCKY"] == 1
+
+    def test_base_enhancement_not_counted(self):
+        from balatro_bot.domain.models.card import Card, CardModifier, CardValue, CardState
+        c = Card(
+            value=CardValue(rank="A", suit="H"),
+            modifier=CardModifier(enhancement="BASE"),
+            state=CardState(),
+        )
+        dp = DeckProfile.from_cards([c])
+        assert dp.enhanced_card_count == 0
+
+
+class TestWildCards:
+    def test_wild_counts_in_all_suits(self):
+        cards = [wild_card("A", "H")]
+        dp = DeckProfile.from_cards(cards)
+        for s in SUITS:
+            assert dp.suit_counts.get(s, 0) == 1
+        assert dp.total_cards == 1
+
+    def test_wild_enhancement_tracked(self):
+        cards = [wild_card("A", "H")]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancement_counts.get("WILD", 0) == 1
+        assert dp.enhanced_card_count == 1
+
+    def test_wild_suit_cross_reference_uses_base_suit(self):
+        """Wild card's enhancement is attributed to its base suit, not all suits."""
+        cards = [wild_card("A", "H")]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancements_by_suit["H"]["WILD"] == 1
+        # Not attributed to other suits
+        assert "D" not in dp.enhancements_by_suit
+
+
+class TestStoneCards:
+    def test_stone_excluded_from_ranks(self):
+        cards = [stone_card(), card("A", "H")]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.total_cards == 2
+        assert dp.rank_counts.get("A", 0) == 1
+        # Stone has no rank, shouldn't appear in rank_counts
+        assert sum(dp.rank_counts.values()) == 1
+
+    def test_stone_counted_as_enhanced(self):
+        dp = DeckProfile.from_cards([stone_card()])
+        assert dp.enhanced_card_count == 1
+        assert dp.enhancement_counts.get("STONE", 0) == 1
+
+
+class TestDriversLicense:
+    def test_below_threshold(self):
+        cards = [card("A", "H", enhancement="STEEL") for _ in range(15)]
+        dp = DeckProfile.from_cards(cards)
+        assert not dp.has_drivers_license_threshold
+
+    def test_at_threshold(self):
+        cards = [card("A", "H", enhancement="STEEL") for _ in range(16)]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.has_drivers_license_threshold
+
+    def test_above_threshold(self):
+        cards = [card("A", "H", enhancement="STEEL") for _ in range(20)]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.has_drivers_license_threshold
+
+
+class TestConvenienceProperties:
+    def test_dominant_suit(self):
+        cards = [card("A", "H")] * 5 + [card("A", "D")] * 3
+        dp = DeckProfile.from_cards(cards)
+        assert dp.dominant_suit == "H"
+
+    def test_dominant_suit_empty(self):
+        dp = DeckProfile.from_cards([])
+        assert dp.dominant_suit is None
+
+    def test_enhancement_suit_concentration(self):
+        cards = [
+            card("A", "H", enhancement="STEEL"),
+            card("K", "H", enhancement="STEEL"),
+            card("Q", "D", enhancement="STEEL"),
+        ]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancement_suit_concentration("STEEL") == "H"
+
+    def test_enhancement_suit_concentration_none(self):
+        dp = DeckProfile.from_cards([card("A", "H")])
+        assert dp.enhancement_suit_concentration("STEEL") is None
+
+    def test_enhancement_rank_concentration(self):
+        cards = [
+            card("K", "H", enhancement="LUCKY"),
+            card("K", "D", enhancement="LUCKY"),
+            card("Q", "H", enhancement="LUCKY"),
+        ]
+        dp = DeckProfile.from_cards(cards)
+        assert dp.enhancement_rank_concentration("LUCKY") == "K"
+
+
+class TestRawDictCards:
+    """DeckProfile should also handle raw dict cards (not just Card objects)."""
+
+    def test_dict_card(self):
+        raw = {
+            "value": {"rank": "A", "suit": "H"},
+            "modifier": {"enhancement": "STEEL"},
+        }
+        dp = DeckProfile.from_cards([raw])
+        assert dp.total_cards == 1
+        assert dp.suit_counts["H"] == 1
+        assert dp.rank_counts["A"] == 1
+        assert dp.enhancement_counts["STEEL"] == 1
+        assert dp.enhancements_by_suit["H"]["STEEL"] == 1
+        assert dp.enhancements_by_rank["A"]["STEEL"] == 1

--- a/tests/test_joker_valuation.py
+++ b/tests/test_joker_valuation.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from tests.conftest import card, joker
+from balatro_bot.domain.models.deck_profile import DeckProfile
 from balatro_bot.domain.policy.shop_valuation import (
     _make_card,
     _synthetic_hand,
     _scoring_delta,
     _synergy_multiplier,
     _context_scale,
+    _deck_composition_adjustment,
     evaluate_joker_value,
     UTILITY_VALUE,
 )
@@ -235,3 +237,175 @@ class TestEvaluateJokerValue:
         j = joker("j_nonexistent_xyz")
         val = evaluate_joker_value(j, [], {}, ante=1)
         assert val == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Baseball Card synergy tests
+# ---------------------------------------------------------------------------
+
+class TestBaseballCardSynergy:
+    def test_baseball_synergy_scales_with_uncommon_count(self):
+        """Baseball Card synergy multiplier should increase with Uncommon count."""
+        strat = Strategy([], [], [], [])
+
+        # 0 Uncommon jokers
+        mult_0 = _synergy_multiplier(
+            "j_baseball", set(), strat, [],
+        )
+        # 2 Uncommon jokers owned
+        owned_2 = [
+            joker("j_jolly", "Jolly Joker", rarity=2),
+            joker("j_zany", "Zany Joker", rarity=2),
+        ]
+        mult_2 = _synergy_multiplier(
+            "j_baseball", {"j_jolly", "j_zany"}, strat, owned_2,
+        )
+        # 3 Uncommon jokers owned
+        owned_3 = owned_2 + [joker("j_crazy", "Crazy Joker", rarity=2)]
+        mult_3 = _synergy_multiplier(
+            "j_baseball", {"j_jolly", "j_zany", "j_crazy"}, strat, owned_3,
+        )
+
+        assert mult_0 == 1.0  # no Uncommons, no bonus
+        assert mult_2 > mult_0  # 2 Uncommons boost Baseball
+        assert mult_3 > mult_2  # 3 Uncommons boost even more
+
+    def test_uncommon_candidate_boosted_when_baseball_owned(self):
+        """Uncommon joker value should be boosted when Baseball Card is owned."""
+        owned = [joker("j_baseball", "Baseball Card", rarity=2)]
+        owned_keys = {"j_baseball"}
+        strat = Strategy([], [], [], [])
+
+        # Uncommon candidate with Baseball owned
+        candidate = joker("j_jolly", "Jolly Joker", rarity=2)
+        mult_with = _synergy_multiplier(
+            "j_jolly", owned_keys, strat, owned, candidate=candidate,
+        )
+        # Same candidate without Baseball
+        mult_without = _synergy_multiplier(
+            "j_jolly", set(), strat, [], candidate=candidate,
+        )
+
+        assert mult_with > mult_without
+
+    def test_common_candidate_not_boosted_by_baseball(self):
+        """Common joker value should NOT be boosted by Baseball Card."""
+        owned = [joker("j_baseball", "Baseball Card", rarity=2)]
+        owned_keys = {"j_baseball"}
+        strat = Strategy([], [], [], [])
+
+        candidate = joker("j_joker", "Joker", rarity=1)
+        mult = _synergy_multiplier(
+            "j_joker", owned_keys, strat, owned, candidate=candidate,
+        )
+
+        assert mult == 1.0  # Common, no Baseball boost
+
+
+# ---------------------------------------------------------------------------
+# Deck composition adjustment tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeckCompositionAdjustment:
+    """Test _deck_composition_adjustment for enhancement-aware joker valuation."""
+
+    def _profile_with_enhancements(self, **enh_counts):
+        """Build a DeckProfile with specific enhancement counts."""
+        cards = []
+        for enh, count in enh_counts.items():
+            for _ in range(count):
+                cards.append(card("A", "H", enhancement=enh))
+        # Pad with plain cards to make 52
+        for _ in range(52 - len(cards)):
+            cards.append(card("2", "S"))
+        return DeckProfile.from_cards(cards)
+
+    def test_steel_joker_no_steel_cards(self):
+        dp = self._profile_with_enhancements()
+        base = 5.0
+        adjusted = _deck_composition_adjustment("j_steel_joker", base, dp, None)
+        assert adjusted < base  # penalized
+
+    def test_steel_joker_with_steel_cards(self):
+        dp = self._profile_with_enhancements(STEEL=5)
+        base = 5.0
+        adjusted = _deck_composition_adjustment("j_steel_joker", base, dp, None)
+        assert adjusted > base  # boosted
+
+    def test_lucky_cat_with_lucky_cards(self):
+        dp = self._profile_with_enhancements(LUCKY=4)
+        base = 3.0
+        adjusted = _deck_composition_adjustment("j_lucky_cat", base, dp, None)
+        assert adjusted > base
+
+    def test_glass_joker_no_glass(self):
+        dp = self._profile_with_enhancements()
+        base = 4.0
+        adjusted = _deck_composition_adjustment("j_glass", base, dp, None)
+        assert adjusted < base
+
+    def test_drivers_license_below_threshold(self):
+        dp = self._profile_with_enhancements(STEEL=5)
+        base = 5.0
+        adjusted = _deck_composition_adjustment("j_drivers_license", base, dp, None)
+        assert adjusted == base * 0.1  # only 5 enhanced < 12
+
+    def test_drivers_license_near_threshold(self):
+        dp = self._profile_with_enhancements(STEEL=14)
+        base = 5.0
+        adjusted = _deck_composition_adjustment("j_drivers_license", base, dp, None)
+        assert adjusted == base * 0.5  # 14 enhanced, between 12-16
+
+    def test_drivers_license_above_threshold(self):
+        dp = self._profile_with_enhancements(STEEL=16)
+        base = 5.0
+        adjusted = _deck_composition_adjustment("j_drivers_license", base, dp, None)
+        assert adjusted == base  # 16 >= 16, full value
+
+    def test_suit_joker_with_enhanced_suit(self):
+        """Bloodstone (Hearts) should get a bonus when Hearts cards are enhanced."""
+        cards = [card("A", "H", enhancement="STEEL") for _ in range(4)]
+        cards += [card("2", "S") for _ in range(48)]
+        dp = DeckProfile.from_cards(cards)
+        base = 3.0
+        adjusted = _deck_composition_adjustment("j_bloodstone", base, dp, None)
+        assert adjusted > base  # Hearts suit has 4 enhanced cards
+
+    def test_suit_joker_no_enhanced_suit(self):
+        """Bloodstone gets no bonus when Hearts cards aren't enhanced."""
+        cards = [card("A", "S", enhancement="STEEL") for _ in range(4)]  # Spades, not Hearts
+        cards += [card("2", "H") for _ in range(48)]  # Hearts unenhanced
+        dp = DeckProfile.from_cards(cards)
+        base = 3.0
+        adjusted = _deck_composition_adjustment("j_bloodstone", base, dp, None)
+        assert adjusted == base
+
+    def test_unrelated_joker_unaffected(self):
+        dp = self._profile_with_enhancements(STEEL=10)
+        base = 4.0
+        adjusted = _deck_composition_adjustment("j_joker", base, dp, None)
+        assert adjusted == base  # plain Joker not in any deck-comp list
+
+
+class TestEvaluateJokerWithDeckProfile:
+    """Integration: evaluate_joker_value respects deck_profile."""
+
+    def test_steel_joker_higher_with_steel_cards(self):
+        candidate = joker("j_steel_joker", "Steel Joker")
+        candidate.setdefault("value", {})["effect"] = "X1.0 Mult"
+        owned = [joker("j_joker", "Joker")]
+        hl = {"Pair": {"chips": 10, "mult": 2, "level": 1, "played": 0, "played_this_round": 0}}
+        strat = compute_strategy(owned, hl)
+
+        no_steel = DeckProfile.from_cards([card("A", "H") for _ in range(52)])
+        with_steel = DeckProfile.from_cards(
+            [card("A", "H", enhancement="STEEL") for _ in range(8)]
+            + [card("2", "S") for _ in range(44)]
+        )
+
+        val_none = evaluate_joker_value(candidate, owned, hl, ante=3, strategy=strat,
+                                         deck_profile=no_steel)
+        val_steel = evaluate_joker_value(candidate, owned, hl, ante=3, strategy=strat,
+                                          deck_profile=with_steel)
+        assert val_steel > val_none

--- a/tests/test_play_discard_policy.py
+++ b/tests/test_play_discard_policy.py
@@ -13,6 +13,7 @@ from balatro_bot.domain.policy.play_policy import (
     choose_milk_play,
 )
 from balatro_bot.domain.policy.discard_policy import choose_discard
+from balatro_bot.domain.scoring.search import cards_not_in
 from balatro_bot.domain.scoring.search import best_hand, HandCandidate
 from balatro_bot.strategy import compute_strategy
 from tests.conftest import card, joker
@@ -273,3 +274,63 @@ class TestRuleDelegation:
         }
         action = PlayBestAvailable().evaluate(state)
         assert isinstance(action, PlayCards)
+
+
+# ---------------------------------------------------------------------------
+# cards_not_in: suit-aware discard ordering
+# ---------------------------------------------------------------------------
+
+class TestCardsNotInSuitAwareness:
+    """cards_not_in should prefer discarding off-suit cards in suit builds."""
+
+    def test_off_suit_discarded_first_in_flush_build(self):
+        from tests.conftest import card
+        from balatro_bot.strategy import Strategy
+
+        # Hand: 3 Hearts (on-suit) + 2 Spades (off-suit)
+        hand = [
+            card("A", "H"), card("K", "H"), card("Q", "H"),  # Hearts — on-suit
+            card("3", "S"), card("2", "S"),                    # Spades — off-suit
+        ]
+        keep = {0}  # keep A♥
+        strat = Strategy(
+            preferred_hands=[("Flush", 5.0)],
+            preferred_suits=[("H", 5.0)],
+        )
+
+        result = cards_not_in(hand, keep, strategy=strat)
+        # Spades (indices 3, 4) should appear before Hearts (1, 2)
+        spade_positions = [result.index(3), result.index(4)]
+        heart_positions = [result.index(1), result.index(2)]
+        assert max(spade_positions) < min(heart_positions), \
+            f"off-suit Spades {spade_positions} should sort before on-suit Hearts {heart_positions}"
+
+    def test_no_strategy_preserves_original_ordering(self):
+        from tests.conftest import card
+
+        hand = [
+            card("A", "H"), card("K", "S"), card("Q", "D"),
+        ]
+        keep = {0}
+
+        with_strat = cards_not_in(hand, keep, strategy=None)
+        without = cards_not_in(hand, keep)
+        assert with_strat == without
+
+    def test_neutral_suit_no_penalty(self):
+        """Cards in suits with zero affinity shouldn't be penalized vs each other."""
+        from tests.conftest import card
+        from balatro_bot.strategy import Strategy
+
+        hand = [
+            card("A", "H"), card("K", "D"), card("Q", "C"),
+        ]
+        keep = set()
+        strat = Strategy(
+            preferred_hands=[("Pair", 3.0)],
+            preferred_suits=[],  # no suit preference
+        )
+
+        result = cards_not_in(hand, keep, strategy=strat)
+        # All three should sort by rank affinity/rank value, not suit
+        assert len(result) == 3

--- a/tests/test_shop_policy.py
+++ b/tests/test_shop_policy.py
@@ -314,3 +314,179 @@ def test_leave_shop_rule_delegates_to_policy() -> None:
     action = LeaveShop().evaluate({})
 
     assert action == NextRound(reason="done shopping")
+
+
+# ── Riff-Raff awareness tests ───────────────────────────────────────
+
+
+def test_sell_dead_riff_raff_when_slots_full() -> None:
+    """Riff-Raff should be sold when all joker slots are full (spawns can't trigger)."""
+    state = {
+        "jokers": {
+            "count": 5,
+            "limit": 5,
+            "cards": [
+                joker("j_riff_raff", "Riff-Raff"),
+                joker("j_joker", "Joker"),
+                joker("j_duo", "Duo"),
+                joker("j_trio", "Trio"),
+                joker("j_family", "Family"),
+            ],
+        },
+    }
+
+    action = choose_sell_weak_joker(state)
+
+    assert action == SellJoker(0, reason="sell dead Riff-Raff (all joker slots full, spawns can't trigger)")
+
+
+def test_sell_weak_common_when_riff_raff_owned_slots_tight() -> None:
+    """When Riff-Raff is owned and count >= limit - 1, sell weak Common jokers."""
+    state = {
+        "jokers": {
+            "count": 4,
+            "limit": 5,
+            "cards": [
+                joker("j_riff_raff", "Riff-Raff"),
+                joker("j_vagabond", "Vagabond", rarity=1),  # Common, value 0.5
+                joker("j_duo", "Duo"),
+                joker("j_trio", "Trio"),
+            ],
+        },
+        "hands": {"Pair": {"level": 1, "chips": 10, "mult": 10}},
+        "ante_num": 3,
+    }
+
+    action = choose_sell_weak_joker(state)
+
+    assert isinstance(action, SellJoker)
+    assert action.index == 1  # Vagabond
+    assert "weak Common" in action.reason
+    assert "Vagabond" in action.reason
+
+
+def test_riff_raff_penalizes_buy_when_reserving_slots() -> None:
+    """Buying a marginal joker should be penalized when Riff-Raff needs spawn slots."""
+    # 3/5 jokers (including Riff-Raff), so Riff-Raff reserves 2 slots.
+    # Buying into slot 4 leaves only 1 free < 2 reserved → 0.7x penalty.
+    # Compare value with and without Riff-Raff to prove the penalty applies.
+    base_state = {
+        "money": 10,
+        "ante_num": 2,
+        "hands": {"Pair": {"level": 1, "chips": 10, "mult": 10}},
+        "jokers": {
+            "count": 3,
+            "limit": 5,
+            "cards": [
+                joker("j_duo", "Duo"),
+                joker("j_trio", "Trio"),
+                joker("j_family", "Family"),
+            ],
+        },
+        "shop": {
+            "cards": [
+                _shop_joker("j_vagabond", "Vagabond", 2),
+            ],
+        },
+    }
+    rr_state = {
+        **base_state,
+        "jokers": {
+            "count": 3,
+            "limit": 5,
+            "cards": [
+                joker("j_riff_raff", "Riff-Raff"),
+                joker("j_duo", "Duo"),
+                joker("j_trio", "Trio"),
+            ],
+        },
+    }
+
+    action_no_rr = choose_buy_joker_in_shop(base_state)
+    action_with_rr = choose_buy_joker_in_shop(rr_state)
+
+    # Both buy Vagabond, but the Riff-Raff version has a lower reported value
+    assert isinstance(action_no_rr, BuyCard)
+    assert isinstance(action_with_rr, BuyCard)
+    # Extract values from reason strings
+    no_rr_val = float(action_no_rr.reason.split("value=")[1].split(",")[0])
+    rr_val = float(action_with_rr.reason.split("value=")[1].split(",")[0])
+    assert rr_val < no_rr_val, f"Riff-Raff penalty not applied: {rr_val} >= {no_rr_val}"
+
+
+def test_riff_raff_no_penalty_when_no_reservation() -> None:
+    """When Riff-Raff is not owned, no slot penalty applies."""
+    state = {
+        "money": 10,
+        "ante_num": 2,
+        "hands": {"Pair": {"level": 1, "chips": 10, "mult": 10}},
+        "jokers": {
+            "count": 2,
+            "limit": 5,
+            "cards": [
+                joker("j_duo", "Duo"),
+                joker("j_trio", "Trio"),
+            ],
+        },
+        "shop": {
+            "cards": [
+                _shop_joker("j_popcorn", "Popcorn", 3, "+20 Mult"),
+            ],
+        },
+    }
+
+    # Without Riff-Raff, Popcorn (ALWAYS_BUY) should be bought normally
+    action = choose_buy_joker_in_shop(state)
+
+    assert isinstance(action, BuyCard)
+    assert "Popcorn" in action.reason
+
+
+def test_riff_raff_stencil_anti_synergy_bidirectional() -> None:
+    """Riff-Raff and Stencil should block each other in both directions."""
+    from balatro_bot.scaling import check_anti_synergy
+
+    # Stencil blocks Riff-Raff (existing)
+    assert check_anti_synergy("j_riff_raff", {"j_stencil"}) == "j_stencil"
+    # Riff-Raff blocks Stencil (existing)
+    assert check_anti_synergy("j_stencil", {"j_riff_raff"}) == "j_riff_raff"
+
+
+# ── Baseball Card awareness tests ──────────���────────────────────────
+
+
+def test_baseball_protects_uncommon_jokers_from_selling() -> None:
+    """Uncommon jokers should be protected from selling when Baseball Card is owned."""
+    # 5/5 slots: Baseball + 2 Uncommons + 2 others. Shop has a decent joker.
+    # Without protection, the weakest Uncommon might get sold for an upgrade.
+    state = {
+        "jokers": {
+            "count": 5,
+            "limit": 5,
+            "cards": [
+                joker("j_baseball", "Baseball Card", rarity=2),
+                joker("j_jolly", "Jolly Joker", rarity=2),
+                joker("j_zany", "Zany Joker", rarity=2),
+                joker("j_duo", "Duo"),
+                joker("j_trio", "Trio"),
+            ],
+        },
+        "hands": {"Pair": {"level": 1, "chips": 10, "mult": 10}},
+        "ante_num": 3,
+        "money": 10,
+        "shop": {
+            "cards": [
+                _shop_joker("j_family", "Family", 4, "X2 Mult if played hand contains a Full House"),
+            ],
+        },
+    }
+
+    action = choose_sell_weak_joker(state)
+
+    # With Baseball protection, Uncommon jokers (Jolly, Zany, Baseball) are protected.
+    # The only sellable candidates are Duo and Trio (both high value) — no upgrade should happen.
+    # If an action is returned, it should NOT sell an Uncommon joker.
+    if action is not None:
+        sold_key = state["jokers"]["cards"][action.index]["key"]
+        assert sold_key not in ("j_baseball", "j_jolly", "j_zany"), \
+            f"Should not sell Uncommon joker {sold_key} when Baseball is owned"

--- a/tests/test_shop_policy.py
+++ b/tests/test_shop_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from balatro_bot.actions import BuyCard, BuyPack, BuyVoucher, NextRound, Reroll, SellConsumable, SellJoker
 from balatro_bot.domain.policy.shop import (
     choose_buy_consumable_in_shop,
@@ -408,9 +410,12 @@ def test_riff_raff_penalizes_buy_when_reserving_slots() -> None:
     # Both buy Vagabond, but the Riff-Raff version has a lower reported value
     assert isinstance(action_no_rr, BuyCard)
     assert isinstance(action_with_rr, BuyCard)
-    # Extract values from reason strings
-    no_rr_val = float(action_no_rr.reason.split("value=")[1].split(",")[0])
-    rr_val = float(action_with_rr.reason.split("value=")[1].split(",")[0])
+    # Extract values from reason strings via regex (resilient to format changes)
+    no_rr_match = re.search(r"value=([\d.]+)", action_no_rr.reason)
+    rr_match = re.search(r"value=([\d.]+)", action_with_rr.reason)
+    assert no_rr_match and rr_match, "Could not parse value from reason strings"
+    no_rr_val = float(no_rr_match.group(1))
+    rr_val = float(rr_match.group(1))
     assert rr_val < no_rr_val, f"Riff-Raff penalty not applied: {rr_val} >= {no_rr_val}"
 
 


### PR DESCRIPTION
## Summary
- **Deck composition tracking** — new `DeckProfile` model tracks suit/rank/enhancement distribution for smarter shop, discard, and pack decisions
- **Discard system overhaul** — real draw probability scoring, all hand types chased, tight/loose discard variants with proper probability math
- **Victory detection simplification** — removed ante-8 timeout hacks; clean single-path detection
- **Integration tests** — win detection, multigame crash reproduction, and multi-game fix verification
- **Code audit fixes** — threaded unused `rank_affinity` params, added missing tiebreaker, removed dead import, consolidated interest calc helper, deduplicated test setup, hardened test assertions

## Changes by commit
1. `fec0169` — Deck composition tracking (`DeckProfile`, shop/pack integration)
2. `23ad046` — Discard system overhaul (chase scoring, tight/loose variants)
3. `2d6ed76` — Simplify victory detection
4. `873414c` — Integration tests for win detection and multigame scenarios
5. `ac020ee` — Audit fix: thread `rank_affinity` in flush_house/flush_five, add `rank_value` tiebreaker, remove dead import
6. `0ca74e8` — Audit fix: consolidate interest calc, broaden modifier guard, fix misleading comment, dedup test setup, use regex in test assertion

## Test plan
- [x] All 410 unit tests pass (`pytest tests/ -q`)
- [ ] Run bot against live game to validate discard decisions
- [ ] Spot-check shop valuations with deck composition active

🤖 Generated with [Claude Code](https://claude.com/claude-code)